### PR TITLE
fix(mobile): stabilize continue-pill query key to stop delete E2E flake

### DIFF
--- a/apps/website/src/pages/mobile/MobileShell.tsx
+++ b/apps/website/src/pages/mobile/MobileShell.tsx
@@ -13,6 +13,7 @@ import {
   useTimeEntriesQuery,
 } from "../../shared/query/web-shell.ts";
 import { resolveTimeEntryProjectId } from "../../features/tracking/time-entry-ids.ts";
+import { getRecentTimeEntryRange } from "../../features/tracking/resolve-query-range.ts";
 import { useSession } from "../../shared/session/session-context.tsx";
 import {
   CalendarIcon,
@@ -43,16 +44,13 @@ export function MobileShell(): ReactElement {
   const runningEntry = currentTimeEntryQuery.data;
   const { showTimeInTitle } = useUserPreferences();
 
-  // Fetch recent entries for continue suggestions
-  const recentEntriesDateRange = (() => {
-    const end = new Date();
-    end.setDate(end.getDate() + 1);
-    const start = new Date();
-    start.setDate(start.getDate() - 7);
-    return { startDate: start.toISOString(), endDate: end.toISOString() };
-  })();
+  // Fetch recent entries for continue suggestions. Use day-granularity dates
+  // (not raw `new Date().toISOString()`) so the query key stays stable across
+  // renders — otherwise every render mints a new key and refetches, which races
+  // optimistic mutations (e.g. a just-deleted entry gets resurrected by the
+  // fresh fetch).
   const recentEntriesQuery = useTimeEntriesQuery({
-    ...recentEntriesDateRange,
+    ...getRecentTimeEntryRange(7),
     workspaceId: session.currentWorkspace.id,
   });
   const recentStoppedEntries = (() => {


### PR DESCRIPTION
## Problem

CI on `main` is red: `e2e/mobile/mobile-timer.spec.ts` › **Delete a Time Entry** fails flakily with a strict-mode violation — after deleting the only entry, `getByText('Entry to delete')` matches **2** elements (the list row *and* the composer's Continue pill), because the deleted entry gets resurrected on screen.

## Root cause

`MobileShell` computed the recent-entries date range with raw `new Date().toISOString()`:

```ts
const recentEntriesDateRange = (() => {
  const end = new Date(); end.setDate(end.getDate() + 1);
  const start = new Date(); start.setDate(start.getDate() - 7);
  return { startDate: start.toISOString(), endDate: end.toISOString() };
})();
```

Those millisecond-precision strings flow into the `["time-entries", …]` query key, so **the key changes on every render**. Each render mints a fresh key and refetches from the network. On delete, `onClose()` → `setEditingEntry(null)` re-renders the shell, spawning a new uncached fetch that races the server delete: the optimistic removal is undone and the entry reappears as both a list row and a Continue pill.

The list view already avoids this by using day-granularity dates (`getRecentTimeEntryRange` → `YYYY-MM-DD`).

## Fix

Reuse the existing `getRecentTimeEntryRange(7)` helper (the same 7-day window, day granularity) so the query key is **stable across renders** — no per-render refetch, and the optimistic delete sticks. Also removes the duplicated range logic.

## Verification

- `Delete a Time Entry` stress-run **10/10 passing** (`--repeat-each 10 --retries 0`).
- Full `mobile-timer.spec.ts` passes (one unrelated pre-existing flaky on retry).
- Unit tests for `resolve-query-range` and `web-shell-time-entries` pass.
- `vp check` (format + lint + types) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012P2AyzvTBB8cfToergx7DR