### PR TITLE
test(e2e): fix flaky mobile delete assertion locator

### DIFF
--- a/apps/website/e2e/mobile/mobile-timer.spec.ts
+++ b/apps/website/e2e/mobile/mobile-timer.spec.ts
@@ -675,9 +675,12 @@ test.describe("Delete a Time Entry", () => {
     // Click delete
     await editor.getByRole("button", { name: "Delete this time entry" }).click();
 
-    // Editor closes and entry is gone
+    // Editor closes and entry is gone. Assert on the row's unique Edit button
+    // instead of getByText: the description also renders in MobileShell's
+    // recent-continue chip, so getByText(ENTRY_DESCRIPTION) legitimately
+    // matches two elements and triggers a strict-mode violation.
     await expect(editor).not.toBeVisible();
-    await expect(page.getByText(ENTRY_DESCRIPTION)).not.toBeVisible();
+    await expect(page.getByRole("button", { name: `Edit ${ENTRY_DESCRIPTION}` })).not.toBeVisible();
   });
 });
 


### PR DESCRIPTION
## Problem

The mobile `"deletes the entry"` e2e test (`e2e/mobile/mobile-timer.spec.ts:661`) is flaky. It intermittently fails CI (seen on #48) with:

```
strict mode violation: getByText('Entry to delete') resolved to 2 elements
```

The entry description renders in **two** places on the mobile timer: the entry row (`MobileTimeEntryRow`) and `MobileShell`'s recent-continue chip (`recentStoppedEntries`). `expect(getByText(...)).not.toBeVisible()` throws a strict-mode violation whenever both render at assertion time — so the test's pass/fail depended purely on whether the chip's query had rendered.

## Fix

Assert on the row's unique `Edit ${ENTRY_DESCRIPTION}` button (the chip uses the `continueEntry` aria-label), which identifies only the list row. This is a precise locator, not a papering-over.

## Verification

Against the real runtime (postgres + redis + backend + frontend):

- Original assertion: **3 flaky / 2 passed** over `--repeat-each=5`
- Fixed assertion: **10/10 passed** over `--repeat-each=10`

🤖 Generated with [Claude Code](https://claude.com/claude-code)