### PR TITLE
perf: optimization audit (backend N+1, DB indexes, bundle/CI/Docker)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ permissions:
   contents: read
   pull-requests: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
@@ -55,18 +59,11 @@ jobs:
               - '.env.example'
               - '.air.toml'
 
-      - uses: pnpm/action-setup@v6
+      - name: Set up Go
         if: steps.changes.outputs.backend_unit == 'true'
-
-      - uses: actions/setup-node@v7
-        if: steps.changes.outputs.backend_unit == 'true'
+        uses: actions/setup-go@v7
         with:
-          node-version: 24
-          cache: "pnpm"
-
-      - name: Install dependencies
-        if: steps.changes.outputs.backend_unit == 'true'
-        run: pnpm install
+          go-version-file: go.mod
 
       - name: Run backend unit tests
         if: steps.changes.outputs.backend_unit == 'true'

--- a/.github/workflows/cli-integration.yml
+++ b/.github/workflows/cli-integration.yml
@@ -13,6 +13,10 @@ permissions:
   contents: read
   pull-requests: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   cli-integration:
     runs-on: ubuntu-latest
@@ -78,6 +82,12 @@ jobs:
       - name: Install dependencies
         if: steps.changes.outputs.cli_integration == 'true'
         run: pnpm install
+
+      - name: Set up Go
+        if: steps.changes.outputs.cli_integration == 'true'
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
 
       - name: Build backend
         if: steps.changes.outputs.cli_integration == 'true'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -76,7 +76,38 @@ jobs:
         with:
           body: ${{ steps.changelog.outputs.content }}
 
+  # The built frontend is arch-independent static JS, so build it once here
+  # instead of repeating it in every leg of the build-binary arch matrix.
+  build-frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - name: Build frontend
+        run: |
+          pnpm install --filter @opentickly/website... --no-frozen-lockfile --ignore-scripts
+          pnpm --filter @opentickly/website run build
+
+      - name: Upload frontend dist
+        uses: actions/upload-artifact@v4
+        with:
+          name: website-dist
+          path: apps/website/dist
+          retention-days: 1
+          if-no-files-found: error
+
   build-binary:
+    needs: build-frontend
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -93,19 +124,11 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v7
+      - name: Download frontend dist
+        uses: actions/download-artifact@v4
         with:
-          node-version: 22
-
-      - name: Install pnpm
-        run: npm install -g pnpm@10.32.1
-
-      - name: Build frontend
-        run: |
-          pnpm install --filter @opentickly/website... --no-frozen-lockfile --ignore-scripts
-          pnpm --filter @opentickly/website run build
-          cp -r apps/website/dist apps/backend/internal/web/dist
+          name: website-dist
+          path: apps/backend/internal/web/dist
 
       - name: Build binary
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,6 +14,10 @@ permissions:
   contents: read
   pull-requests: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   e2e:
     runs-on: ubuntu-latest
@@ -81,15 +85,21 @@ jobs:
         if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.website_e2e == 'true'
         run: pnpm install
 
+      - name: Set up Go
+        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.website_e2e == 'true'
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+
       - name: Build backend
         if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.website_e2e == 'true'
         env:
           CGO_ENABLED: 0
         run: go build -o /tmp/opentoggl ./apps/backend
 
-      - name: Build frontend
+      - name: Typecheck frontend
         if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.website_e2e == 'true'
-        run: pnpm --filter @opentickly/website run build
+        run: pnpm --filter @opentickly/website exec tsc -p tsconfig.json --noEmit
 
       - name: Install Playwright dependencies
         if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.website_e2e == 'true'

--- a/.github/workflows/schema-verify.yml
+++ b/.github/workflows/schema-verify.yml
@@ -35,6 +35,11 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+
       - name: Verify latest.sql matches migrations
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,20 @@ WORKDIR /workspace
 RUN npm install -g pnpm@10.32.1
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json ./
+
+# Manifests-first: copy every workspace member's package.json so pnpm can resolve
+# the full graph, keeping the install layer cached across source-only edits.
+COPY apps/website/package.json ./apps/website/
+COPY apps/landing/package.json ./apps/landing/
+COPY apps/update-worker/package.json ./apps/update-worker/
+COPY packages/web-ui/package.json ./packages/web-ui/
+COPY packages/shared-contracts/package.json ./packages/shared-contracts/
+
+RUN pnpm install --filter @opentickly/website... --no-frozen-lockfile --ignore-scripts
+
 COPY apps/website ./apps/website
 COPY packages ./packages
 
-RUN pnpm install --filter @opentickly/website... --no-frozen-lockfile --ignore-scripts
 RUN pnpm --filter @opentickly/website run build
 
 FROM --platform=$BUILDPLATFORM golang:1.25.10-alpine AS builder
@@ -33,11 +43,9 @@ FROM alpine:3.22
 WORKDIR /app
 
 COPY --from=builder /out/opentoggl /usr/local/bin/opentoggl
-COPY apps/backend/opentoggl-entrypoint.sh /usr/local/bin/opentoggl-entrypoint
+COPY --chmod=0755 apps/backend/opentoggl-entrypoint.sh /usr/local/bin/opentoggl-entrypoint
 
-RUN apk add --no-cache ca-certificates wget tzdata
-RUN printf '# required by current bootstrap env loader for runtime startup\n' > /app/.env.local
-RUN chmod +x /usr/local/bin/opentoggl-entrypoint
+RUN apk add --no-cache ca-certificates tzdata
 
 ARG OPENTOGGL_VERSION=dev
 LABEL org.opencontainers.image.title="OpenTickly" \
@@ -45,7 +53,8 @@ LABEL org.opencontainers.image.title="OpenTickly" \
       org.opencontainers.image.source="https://github.com/CorrectRoadH/OpenTickly" \
       org.opencontainers.image.version="${OPENTOGGL_VERSION}"
 
-RUN adduser -D -u 10001 opentoggl
+RUN printf '# required by current bootstrap env loader for runtime startup\n' > /app/.env.local \
+    && adduser -D -u 10001 opentoggl
 USER opentoggl
 
 EXPOSE 8080

--- a/apps/backend/db/schema/latest.sql
+++ b/apps/backend/db/schema/latest.sql
@@ -191,7 +191,6 @@ create table membership_workspace_members (
     constraint membership_workspace_members_state_check check (state in ('invited', 'joined', 'disabled', 'restored', 'removed'))
 );
 
-create index membership_workspace_members_workspace_id_idx on membership_workspace_members (workspace_id);
 create unique index membership_workspace_members_workspace_email_key on membership_workspace_members (workspace_id, lower(email));
 create unique index membership_workspace_members_workspace_user_key
     on membership_workspace_members (workspace_id, user_id)
@@ -236,7 +235,6 @@ create table catalog_clients (
     created_at timestamptz not null default now()
 );
 
-create index catalog_clients_workspace_id_idx on catalog_clients (workspace_id);
 create unique index catalog_clients_workspace_name_key on catalog_clients (workspace_id, lower(name));
 
 create table catalog_projects (
@@ -263,7 +261,6 @@ create table catalog_projects (
     created_at timestamptz not null default now()
 );
 
-create index catalog_projects_workspace_id_idx on catalog_projects (workspace_id);
 create index catalog_projects_client_id_idx on catalog_projects (client_id);
 create unique index catalog_projects_workspace_name_key on catalog_projects (workspace_id, lower(name));
 
@@ -286,7 +283,6 @@ create table catalog_groups (
     created_at timestamptz not null default now()
 );
 
-create index catalog_groups_organization_id_idx on catalog_groups (organization_id);
 create unique index catalog_groups_organization_name_key on catalog_groups (organization_id, lower(name));
 
 create table catalog_group_members (
@@ -326,7 +322,6 @@ create table catalog_tags (
     created_at timestamptz not null default now()
 );
 
-create index catalog_tags_workspace_id_idx on catalog_tags (workspace_id);
 create unique index catalog_tags_workspace_name_key on catalog_tags (workspace_id, lower(name));
 
 create table catalog_tasks (
@@ -339,7 +334,6 @@ create table catalog_tasks (
     created_at timestamptz not null default now()
 );
 
-create index catalog_tasks_workspace_id_idx on catalog_tasks (workspace_id);
 create index catalog_tasks_project_id_idx on catalog_tasks (project_id);
 create unique index catalog_tasks_workspace_name_key on catalog_tasks (workspace_id, lower(name));
 
@@ -392,7 +386,9 @@ create table tracking_time_entries (
 );
 
 create index tracking_time_entries_workspace_user_start_idx on tracking_time_entries (workspace_id, user_id, start_time);
+create index tracking_time_entries_workspace_start_idx on tracking_time_entries (workspace_id, start_time);
 create index tracking_time_entries_user_id_idx on tracking_time_entries (user_id);
+create index tracking_time_entries_client_id_idx on tracking_time_entries (client_id);
 create index tracking_time_entries_project_id_idx on tracking_time_entries (project_id);
 create index tracking_time_entries_task_id_idx on tracking_time_entries (task_id);
 create index tracking_time_entries_start_time_idx on tracking_time_entries (start_time);

--- a/apps/backend/internal/catalog/application/catalog_objects_test.go
+++ b/apps/backend/internal/catalog/application/catalog_objects_test.go
@@ -61,8 +61,8 @@ func TestServicePersistsCatalogStateWithPostgresStore(t *testing.T) {
 
 	group, err := service.CreateGroup(ctx, catalogapplication.CreateGroupCommand{
 		OrganizationID: organizationID,
-		CreatedBy:   userID,
-		Name:        "Core Team",
+		CreatedBy:      userID,
+		Name:           "Core Team",
 	})
 	if err != nil {
 		t.Fatalf("create group: %v", err)
@@ -393,8 +393,8 @@ func TestServiceSupportsAdditionalCatalogMutations(t *testing.T) {
 
 	group, err := service.CreateGroup(ctx, catalogapplication.CreateGroupCommand{
 		OrganizationID: organizationID,
-		CreatedBy:   userID,
-		Name:        "Team A",
+		CreatedBy:      userID,
+		Name:           "Team A",
 	})
 	if err != nil {
 		t.Fatalf("create group: %v", err)
@@ -427,6 +427,24 @@ func TestServiceSupportsAdditionalCatalogMutations(t *testing.T) {
 	}
 	if len(userCounts) != 1 || userCounts[0].Count != 1 {
 		t.Fatalf("expected one user count, got %#v", userCounts)
+	}
+
+	// A duplicate existing id must still succeed (one count row, no error).
+	dupCounts, err := service.CountProjectTasks(ctx, workspaceID, []int64{project.ID, project.ID})
+	if err != nil {
+		t.Fatalf("count project tasks with duplicate id: %v", err)
+	}
+	if len(dupCounts) != 1 {
+		t.Fatalf("expected one count row for duplicate id, got %#v", dupCounts)
+	}
+
+	// A non-existent project id must surface ErrProjectNotFound (existence is
+	// derived from the count result set, not a per-id lookup).
+	if _, err := service.CountProjectTasks(ctx, workspaceID, []int64{project.ID, project.ID + 99999}); !errors.Is(err, catalogapplication.ErrProjectNotFound) {
+		t.Fatalf("expected ErrProjectNotFound for missing project id, got %v", err)
+	}
+	if _, err := service.CountProjectUsers(ctx, workspaceID, []int64{project.ID + 99999}); !errors.Is(err, catalogapplication.ErrProjectNotFound) {
+		t.Fatalf("expected ErrProjectNotFound for missing project id, got %v", err)
 	}
 
 	secondUserID := seedCatalogIdentityUser(t, ctx, database, 202, "teammate@example.com", "Teammate User")
@@ -604,8 +622,8 @@ func TestServicePersistsProjectGroupAssignments(t *testing.T) {
 	}
 	group, err := service.CreateGroup(ctx, catalogapplication.CreateGroupCommand{
 		OrganizationID: organizationID,
-		CreatedBy:   userID,
-		Name:        "Delivery Team",
+		CreatedBy:      userID,
+		Name:           "Delivery Team",
 	})
 	if err != nil {
 		t.Fatalf("create group: %v", err)

--- a/apps/backend/internal/catalog/application/project_groups.go
+++ b/apps/backend/internal/catalog/application/project_groups.go
@@ -13,12 +13,8 @@ func (service *Service) ListProjectGroups(
 	if len(projectIDs) == 0 {
 		return []ProjectGroupView{}, nil
 	}
-	for _, projectID := range projectIDs {
-		if _, ok, err := service.store.GetProject(ctx, workspaceID, projectID); err != nil {
-			return nil, err
-		} else if !ok {
-			return nil, ErrProjectNotFound
-		}
+	if err := service.ensureProjectsExist(ctx, workspaceID, projectIDs); err != nil {
+		return nil, err
 	}
 	return service.store.ListProjectGroups(ctx, workspaceID, projectIDs)
 }

--- a/apps/backend/internal/catalog/application/service_projects.go
+++ b/apps/backend/internal/catalog/application/service_projects.go
@@ -2,6 +2,7 @@ package application
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"opentoggl/backend/apps/backend/internal/catalog/domain"
@@ -211,10 +212,10 @@ func (service *Service) SetProjectPinned(ctx context.Context, command SetProject
 }
 
 type DeleteProjectCommand struct {
-	WorkspaceID      int64
-	ProjectID        int64
-	TEDeletionMode   string // "unassign" (default) or "delete"
-	ReassignToID     *int64 // if set, reassign time entries to this project before deleting
+	WorkspaceID    int64
+	ProjectID      int64
+	TEDeletionMode string // "unassign" (default) or "delete"
+	ReassignToID   *int64 // if set, reassign time entries to this project before deleting
 }
 
 func (service *Service) DeleteProject(ctx context.Context, workspaceID int64, projectID int64) error {
@@ -316,28 +317,65 @@ func (service *Service) CountProjectTasks(ctx context.Context, workspaceID int64
 	if err := requireWorkspaceID(workspaceID); err != nil {
 		return nil, err
 	}
-	for _, projectID := range projectIDs {
-		if _, ok, err := service.store.GetProject(ctx, workspaceID, projectID); err != nil {
-			return nil, err
-		} else if !ok {
-			return nil, ErrProjectNotFound
-		}
+	// The count query returns exactly one row per existing project id, so
+	// existence is derivable from result-set membership — no per-id lookup.
+	counts, err := service.store.CountProjectTasks(ctx, workspaceID, projectIDs)
+	if err != nil {
+		return nil, err
 	}
-	return service.store.CountProjectTasks(ctx, workspaceID, projectIDs)
+	if err := ensureAllProjectsCounted(projectIDs, counts); err != nil {
+		return nil, err
+	}
+	return counts, nil
 }
 
 func (service *Service) CountProjectUsers(ctx context.Context, workspaceID int64, projectIDs []int64) ([]ProjectCountView, error) {
 	if err := requireWorkspaceID(workspaceID); err != nil {
 		return nil, err
 	}
-	for _, projectID := range projectIDs {
-		if _, ok, err := service.store.GetProject(ctx, workspaceID, projectID); err != nil {
-			return nil, err
-		} else if !ok {
-			return nil, ErrProjectNotFound
+	counts, err := service.store.CountProjectUsers(ctx, workspaceID, projectIDs)
+	if err != nil {
+		return nil, err
+	}
+	if err := ensureAllProjectsCounted(projectIDs, counts); err != nil {
+		return nil, err
+	}
+	return counts, nil
+}
+
+// ensureAllProjectsCounted verifies every requested project id produced a count
+// row (i.e. exists in the workspace), returning ErrProjectNotFound otherwise.
+// Handles duplicate ids in the request naturally by checking membership.
+func ensureAllProjectsCounted(requested []int64, counts []ProjectCountView) error {
+	present := make(map[int64]struct{}, len(counts))
+	for _, c := range counts {
+		present[c.ProjectID] = struct{}{}
+	}
+	for _, id := range requested {
+		if _, ok := present[id]; !ok {
+			return ErrProjectNotFound
 		}
 	}
-	return service.store.CountProjectUsers(ctx, workspaceID, projectIDs)
+	return nil
+}
+
+// ensureProjectsExist validates that every id in projectIDs exists in the
+// workspace using a single batched lookup instead of one GetProject per id.
+func (service *Service) ensureProjectsExist(ctx context.Context, workspaceID int64, projectIDs []int64) error {
+	existing, err := service.store.ExistingProjectIDs(ctx, workspaceID, projectIDs)
+	if err != nil {
+		return err
+	}
+	present := make(map[int64]struct{}, len(existing))
+	for _, id := range existing {
+		present[id] = struct{}{}
+	}
+	for _, id := range projectIDs {
+		if _, ok := present[id]; !ok {
+			return ErrProjectNotFound
+		}
+	}
+	return nil
 }
 
 func (service *Service) PatchProjects(
@@ -356,21 +394,20 @@ func (service *Service) PatchProjects(
 		"workspace_id", workspaceID,
 		"project_ids", projectIDs,
 	)
-	for _, projectID := range projectIDs {
-		if _, ok, err := service.store.GetProject(ctx, workspaceID, projectID); err != nil {
-			service.logger.ErrorContext(ctx, "failed to get project for patching",
-				"workspace_id", workspaceID,
-				"project_id", projectID,
-				"error", err.Error(),
-			)
-			return nil, err
-		} else if !ok {
+	if err := service.ensureProjectsExist(ctx, workspaceID, projectIDs); err != nil {
+		if errors.Is(err, ErrProjectNotFound) {
 			service.logger.WarnContext(ctx, "project not found for patching",
 				"workspace_id", workspaceID,
-				"project_id", projectID,
+				"project_ids", projectIDs,
 			)
-			return nil, ErrProjectNotFound
+		} else {
+			service.logger.ErrorContext(ctx, "failed to get projects for patching",
+				"workspace_id", workspaceID,
+				"project_ids", projectIDs,
+				"error", err.Error(),
+			)
 		}
+		return nil, err
 	}
 
 	if err := service.store.PatchProjects(ctx, workspaceID, projectIDs, commands); err != nil {

--- a/apps/backend/internal/catalog/application/types.go
+++ b/apps/backend/internal/catalog/application/types.go
@@ -360,6 +360,7 @@ type Store interface {
 	UnassignProjectTimeEntries(ctx context.Context, workspaceID int64, projectID int64) (int64, error)
 	CountProjectTasks(context.Context, int64, []int64) ([]ProjectCountView, error)
 	CountProjectUsers(context.Context, int64, []int64) ([]ProjectCountView, error)
+	ExistingProjectIDs(context.Context, int64, []int64) ([]int64, error)
 	SetProjectPinned(context.Context, int64, int64, bool) error
 	ListTasks(context.Context, int64, ListTasksFilter) (TaskPage, error)
 	GetTask(context.Context, int64, int64) (TaskView, bool, error)

--- a/apps/backend/internal/catalog/infra/postgres/store_read.go
+++ b/apps/backend/internal/catalog/infra/postgres/store_read.go
@@ -498,6 +498,37 @@ func (store *Store) CountProjectUsers(
 	return counts, rows.Err()
 }
 
+// ExistingProjectIDs returns the subset of projectIDs that exist in the
+// workspace. Callers that only need to validate project existence use this
+// single indexed lookup instead of issuing one GetProject per id (each of
+// which carries a lateral SUM over the project's time entries).
+func (store *Store) ExistingProjectIDs(
+	ctx context.Context,
+	workspaceID int64,
+	projectIDs []int64,
+) ([]int64, error) {
+	rows, err := store.pool.Query(
+		ctx,
+		`select id from catalog_projects where workspace_id = $1 and id = any($2)`,
+		workspaceID,
+		int64SliceOrNil(projectIDs),
+	)
+	if err != nil {
+		return nil, writeCatalogError("existing project ids", err)
+	}
+	defer rows.Close()
+
+	ids := make([]int64, 0, len(projectIDs))
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, writeCatalogError("scan existing project id", err)
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
 func (store *Store) ListTasks(
 	ctx context.Context,
 	workspaceID int64,

--- a/apps/backend/internal/platform/handles.go
+++ b/apps/backend/internal/platform/handles.go
@@ -3,12 +3,21 @@ package platform
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	platformconfig "opentoggl/backend/apps/backend/internal/platform/config"
 	"opentoggl/backend/apps/backend/internal/platform/safehttp"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 )
+
+// defaultWebMaxConns is the connection-pool floor for web workloads. pgx
+// defaults MaxConns to max(4, runtime.NumCPU()), which caps a small (1-2 vCPU)
+// self-hosted container at 4 while request handlers hold a connection across
+// several sequential queries (session resolve, workspace authorization, work),
+// serializing concurrent requests on acquisition. Operators can still pin an
+// explicit ceiling via the DSN (?pool_max_conns=N).
+const defaultWebMaxConns = 10
 
 // Services is a small compile-time boundary marker for the composition root.
 // apps/backend only needs to know it received platform services, not how later
@@ -67,7 +76,18 @@ type DatabaseHandle struct {
 }
 
 func NewDatabaseHandle(primaryDSN string) (DatabaseHandle, error) {
-	pool, err := pgxpool.New(context.Background(), primaryDSN)
+	poolCfg, err := pgxpool.ParseConfig(primaryDSN)
+	if err != nil {
+		return DatabaseHandle{}, err
+	}
+
+	// Only raise the floor: respect an operator-pinned pool_max_conns and any
+	// larger CPU-derived default; bump only the small-container case.
+	if !strings.Contains(strings.ToLower(primaryDSN), "pool_max_conns") && poolCfg.MaxConns < defaultWebMaxConns {
+		poolCfg.MaxConns = defaultWebMaxConns
+	}
+
+	pool, err := pgxpool.NewWithConfig(context.Background(), poolCfg)
 	if err != nil {
 		return DatabaseHandle{}, err
 	}

--- a/apps/backend/internal/platform/migrate/migrations/00017_add_time_entry_lookup_indexes.sql
+++ b/apps/backend/internal/platform/migrate/migrations/00017_add_time_entry_lookup_indexes.sql
@@ -1,0 +1,19 @@
+-- +goose Up
+-- Workspace-wide report/dashboard queries filter tracking_time_entries by
+-- workspace_id (no user_id predicate) and order by start_time. The existing
+-- (workspace_id, user_id, start_time) index cannot serve a bounded ordered
+-- range scan on start_time because user_id sits between the two, forcing a
+-- full workspace index scan plus an in-memory sort. A (workspace_id, start_time)
+-- composite serves those queries directly.
+create index if not exists tracking_time_entries_workspace_start_idx
+    on tracking_time_entries (workspace_id, start_time);
+
+-- client_id is an FK to catalog_clients with ON DELETE SET NULL but, unlike the
+-- sibling project_id/task_id FKs, has no index. Deleting a client therefore
+-- sequentially scans the largest table to null referencing rows.
+create index if not exists tracking_time_entries_client_id_idx
+    on tracking_time_entries (client_id);
+
+-- +goose Down
+drop index if exists tracking_time_entries_client_id_idx;
+drop index if exists tracking_time_entries_workspace_start_idx;

--- a/apps/backend/internal/platform/migrate/migrations/00018_drop_redundant_catalog_indexes.sql
+++ b/apps/backend/internal/platform/migrate/migrations/00018_drop_redundant_catalog_indexes.sql
@@ -1,0 +1,21 @@
+-- +goose Up
+-- Each of these standalone single-column indexes is a strict leading-column
+-- prefix of an existing UNIQUE composite on the same table, so the composite
+-- already serves both equality lookups (col = $1) and FK-cascade scans on that
+-- column. The standalone indexes only add write/maintenance amplification on
+-- the catalog write/import paths. (Same optimization migration 00013 applied to
+-- tracking_time_entries_workspace_id_idx.)
+drop index if exists catalog_clients_workspace_id_idx;              -- prefix of catalog_clients_workspace_name_key (workspace_id, lower(name))
+drop index if exists catalog_projects_workspace_id_idx;            -- prefix of catalog_projects_workspace_name_key (workspace_id, lower(name))
+drop index if exists catalog_tags_workspace_id_idx;               -- prefix of catalog_tags_workspace_name_key (workspace_id, lower(name))
+drop index if exists catalog_tasks_workspace_id_idx;              -- prefix of catalog_tasks_workspace_name_key (workspace_id, lower(name))
+drop index if exists catalog_groups_organization_id_idx;          -- prefix of catalog_groups_organization_name_key (organization_id, lower(name))
+drop index if exists membership_workspace_members_workspace_id_idx; -- prefix of membership_workspace_members_workspace_user_key (workspace_id, user_id)
+
+-- +goose Down
+create index if not exists catalog_clients_workspace_id_idx on catalog_clients (workspace_id);
+create index if not exists catalog_projects_workspace_id_idx on catalog_projects (workspace_id);
+create index if not exists catalog_tags_workspace_id_idx on catalog_tags (workspace_id);
+create index if not exists catalog_tasks_workspace_id_idx on catalog_tasks (workspace_id);
+create index if not exists catalog_groups_organization_id_idx on catalog_groups (organization_id);
+create index if not exists membership_workspace_members_workspace_id_idx on membership_workspace_members (workspace_id);

--- a/apps/website/src/shared/query/web-shell-favorites.ts
+++ b/apps/website/src/shared/query/web-shell-favorites.ts
@@ -18,6 +18,7 @@ export function useFavoritesQuery(workspaceId: number) {
         }),
       ),
     queryKey: favoritesQueryKey(workspaceId),
+    staleTime: 60 * 1000,
   });
 }
 

--- a/apps/website/src/shared/query/web-shell-goals.ts
+++ b/apps/website/src/shared/query/web-shell-goals.ts
@@ -30,6 +30,7 @@ export function useGoalsQuery(workspaceId: number, active?: boolean) {
         }),
       ) as Promise<HandlergoalsApiResponse[]>,
     queryKey: goalsQueryKey(workspaceId, active),
+    staleTime: 60 * 1000,
   });
 }
 

--- a/apps/website/src/shared/query/web-shell-projects.ts
+++ b/apps/website/src/shared/query/web-shell-projects.ts
@@ -53,6 +53,7 @@ export function useProjectsQuery(workspaceId: number, status: ProjectListStatusF
         }),
       ),
     queryKey: projectsQueryKey(workspaceId, status),
+    staleTime: 60 * 1000,
   });
 }
 

--- a/apps/website/src/shared/query/web-shell-tags.ts
+++ b/apps/website/src/shared/query/web-shell-tags.ts
@@ -19,6 +19,7 @@ export function useTagsQuery(workspaceId: number) {
         }),
       ),
     queryKey: ["tags", workspaceId],
+    staleTime: 60 * 1000,
   });
 }
 

--- a/apps/website/src/shared/ui/AnimatedActiveIndicator.tsx
+++ b/apps/website/src/shared/ui/AnimatedActiveIndicator.tsx
@@ -1,14 +1,9 @@
-import { motion } from "motion/react";
+import { lazy, Suspense } from "react";
 import type { ReactElement } from "react";
 
 import { useUserPreferences } from "../query/useUserPreferences.ts";
 
-const activeIndicatorTransition = {
-  damping: 40,
-  mass: 0.45,
-  stiffness: 520,
-  type: "spring",
-} as const;
+const MotionActiveIndicator = lazy(() => import("./MotionActiveIndicator.tsx"));
 
 export function AnimatedActiveIndicator({
   className,
@@ -19,16 +14,15 @@ export function AnimatedActiveIndicator({
 }): ReactElement {
   const { showAnimations } = useUserPreferences();
 
+  const plain = <span aria-hidden="true" className={className} />;
+
   if (typeof window === "undefined" || !showAnimations) {
-    return <span aria-hidden="true" className={className} />;
+    return plain;
   }
 
   return (
-    <motion.span
-      aria-hidden="true"
-      className={className}
-      layoutId={layoutId}
-      transition={activeIndicatorTransition}
-    />
+    <Suspense fallback={plain}>
+      <MotionActiveIndicator className={className} layoutId={layoutId} />
+    </Suspense>
   );
 }

--- a/apps/website/src/shared/ui/MotionActiveIndicator.tsx
+++ b/apps/website/src/shared/ui/MotionActiveIndicator.tsx
@@ -1,0 +1,30 @@
+import { motion } from "motion/react";
+import type { ReactElement } from "react";
+
+const activeIndicatorTransition = {
+  damping: 40,
+  mass: 0.45,
+  stiffness: 520,
+  type: "spring",
+} as const;
+
+// Isolated so the ~39KB gz Motion runtime is code-split out of the eager
+// app-shell entry chunk and only fetched when an animated indicator actually
+// renders (animations enabled, client-side). Loaded lazily by
+// AnimatedActiveIndicator behind a plain <span> fallback.
+export default function MotionActiveIndicator({
+  className,
+  layoutId,
+}: {
+  className: string;
+  layoutId: string;
+}): ReactElement {
+  return (
+    <motion.span
+      aria-hidden="true"
+      className={className}
+      layoutId={layoutId}
+      transition={activeIndicatorTransition}
+    />
+  );
+}

--- a/apps/website/vite.config.ts
+++ b/apps/website/vite.config.ts
@@ -107,11 +107,17 @@ export default defineConfig(() => {
         },
         injectManifest: {
           globPatterns: ["**/*.{js,css,html,ico,png,svg,woff2}"],
+          // The onboarding screenshots (~3MB of PNGs) are only ever seen once,
+          // by users who have not completed onboarding. Precaching them for
+          // every visitor wastes bandwidth; let them load on demand instead.
+          globIgnores: ["**/onboarding/*.png"],
         },
       }),
     ],
     build: {
-      modulePreload: false,
+      // modulePreload left at Vite's default so the entry's static vendor
+      // chunks are discovered via injected <link rel="modulepreload"> hints
+      // instead of a serial html -> entry -> vendors waterfall.
       chunkSizeWarningLimit: 1000,
       rollupOptions: {
         output: {

--- a/packages/web-ui/package.json
+++ b/packages/web-ui/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
+  "sideEffects": [
+    "**/*.css"
+  ],
   "exports": {
     ".": "./src/index.ts",
     "./tokens.css": "./src/tokens.css",


### PR DESCRIPTION
## What this is

A verified subset of a multi-dimensional optimization audit (perf + infra + deps). Findings were surfaced by specialized finders and adversarially verified against the actual code + `docs/`/`openapi/` before being acted on. This PR ships **only the changes I could verify end-to-end**; correctness-sensitive and unbuildable items are deferred (see below).

> [!IMPORTANT]
> **The landing build is broken on `main` independent of this PR** — this PR does not touch it. A recent dependabot bump of `@react-router/dev` to **8.2.0** both removed the `future.v8_middleware` config flag *and* raised the Node floor to `> 22.22.0`, while the repo pins Node **22.12.0** (`Dockerfile.landing`) / declares `>=22.12.0` engines. `docker-landing.yml` (push-to-main, paths `apps/landing/**` + `packages/**`) will fail on this until fixed. Fixing it is a coordinated Node-vs-react-router decision on the GitOps-sensitive deploy path and deserves its own PR — the landing perf changes (below) are held for that PR.

## Shipped & verified

**Backend**
- **Catalog N+1** — `CountProjectTasks`/`CountProjectUsers`/`PatchProjects`/`ListProjectGroups` validated project IDs with one `GetProject` per id, each running (and discarding) a lateral `SUM` over the project's time entries. Existence is now derived from the batched result set / a single `ExistingProjectIDs` lookup. A 100-project count request drops from ~101 queries to 1. Added missing-id/duplicate-id characterization tests.
- **DB indexes** — new `(workspace_id, start_time)` index (workspace-wide report/dashboard scans have no `user_id` predicate, so the existing `(workspace_id, user_id, start_time)` couldn't serve a bounded range scan); new `client_id` FK index (client deletion was seq-scanning the largest table); dropped 6 redundant single-column indexes that are prefixes of a UNIQUE composite. `latest.sql` updated; schema-verify test passes.
- **pgxpool** — raise the `MaxConns` floor to 10 for small self-hosted containers, but only when the operator hasn't pinned `pool_max_conns` and the CPU default is lower.

**Website** (all verified by inspecting the built artifacts)
- `modulePreload` waterfall fix → **63 modulepreload links** now emitted.
- `staleTime: 60s` on projects/tags/favorites/goals to stop the focus-refetch storm.
- Code-split `motion/react` via lazy/Suspense → motion runtime now **only** in the `MotionActiveIndicator` chunk, **absent from the entry/web-shell** chunks.
- `globIgnores` onboarding PNGs → **0 onboarding PNGs in the precache manifest** (~3MB no longer precached for every visitor).

**web-ui** (the headline finding)
- Declare `sideEffects: ["**/*.css"]` so the barrel's unused `appTheme`/`theme.ts` (which imports baseui `LightTheme`) tree-shakes out. Verified: a landing client build now has **0 occurrences of LightTheme/styletron/baseui**; home chunk ~167KB → ~24–33KB.

**CI/CD**
- Concurrency groups on ci/e2e/cli so superseded PR pushes cancel.
- `setup-go` build/module caching on e2e/cli/schema-verify; dropped the Node+pnpm setup a `go test`-only job never used.
- e2e: swap the orphaned prod frontend build (dist is never served) for its `tsc --noEmit` typecheck.
- docker.yml (release-only): build the arch-independent frontend **once** and reuse across the build-binary arch matrix instead of 3×.

**Docker (main image)**
- website-builder manifests-first so a source edit no longer busts the pnpm install layer (validated with a real `--target website-builder` build).
- Slimmer runtime stage: drop redundant GNU `wget`, `COPY --chmod`, merged RUN layers.

## Verification
- Full backend test suite (CI's list) green against Postgres 17, incl. new catalog tests + schema-verify.
- `vp check` clean on all changed files (the one repo-wide lint error is the pre-existing `v8_middleware`, not from this PR).
- Website `tsc --noEmit` + build green; artifacts inspected for each frontend claim.
- Main Dockerfile `website-builder` stage built successfully (exit 0).
- All 5 touched workflows YAML-parse clean.

## Deferred (not in this PR — with reasons)
- **Report over-fetch pushdown** (biggest scalability win): 5 heterogeneous call sites + only unit coverage of `matchesQueryFilters` (no DB-backed day-boundary test). A too-narrow SQL `until` silently drops report entries → needs its own PR *with* DST/month-edge boundary tests.
- **recent-suggestions 90-day cutoff**: the openapi contract defines **no** "recent" window, so bounding it is a product/behavior decision (would drop suggestions for monthly-recurring tasks), not an implementation fix.
- **Landing perf** (serve.json cache headers, optimize-images mtime gate, Dockerfile.landing manifests-first + postinstall dedup, remove unused `isbot`): correct and individually verified, but held for the landing-build-fix PR since they can't be validated end-to-end while the build is broken.
- **Redundant covering index** for project totals: write-amplification tradeoff on the highest-write table — skipped.
- **Replace `@uidotdev/usehooks` `useRenderCount`**: low value; needs a cross-package placement decision (website + web-ui both consume it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
