### PR TITLE
perf(tracking): bound unbounded report + recent-suggestions scans (#2, #5)

### DIFF
--- a/apps/backend/internal/reports/application/service.go
+++ b/apps/backend/internal/reports/application/service.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"time"
 
+	"opentoggl/backend/apps/backend/internal/log"
 	membershipapplication "opentoggl/backend/apps/backend/internal/membership/application"
 	trackingapplication "opentoggl/backend/apps/backend/internal/tracking/application"
-	"opentoggl/backend/apps/backend/internal/log"
 )
 
 type SavedReportStore interface {
@@ -33,6 +33,7 @@ type TrackingQueries interface {
 		ctx context.Context,
 		workspaceID int64,
 		since *time.Time,
+		until *time.Time,
 	) ([]trackingapplication.TimeEntryView, error)
 }
 
@@ -130,7 +131,8 @@ func (service *Service) BuildWeeklyReportEntries(
 ) ([]trackingapplication.TimeEntryView, error) {
 	location := resolveLocation(query.Timezone)
 	startUTC := query.StartDate.In(location).UTC()
-	entries, err := service.tracking.ListWorkspaceTimeEntries(ctx, query.WorkspaceID, &startUTC)
+	until := reportUntil(query.EndDate, location)
+	entries, err := service.tracking.ListWorkspaceTimeEntries(ctx, query.WorkspaceID, &startUTC, &until)
 	if err != nil {
 		return nil, err
 	}
@@ -175,7 +177,8 @@ func (service *Service) BuildWeeklyReport(ctx context.Context, query Query) (Wee
 	)
 	location := resolveLocation(query.Timezone)
 	startUTC := query.StartDate.In(location).UTC()
-	entries, err := service.tracking.ListWorkspaceTimeEntries(ctx, query.WorkspaceID, &startUTC)
+	until := reportUntil(query.EndDate, location)
+	entries, err := service.tracking.ListWorkspaceTimeEntries(ctx, query.WorkspaceID, &startUTC, &until)
 	if err != nil {
 		service.logger.ErrorContext(ctx, "failed to get time entries for weekly report",
 			"workspace_id", query.WorkspaceID,
@@ -384,8 +387,11 @@ func (service *Service) BuildProjectDataTrends(ctx context.Context, query Projec
 		earliest = *query.PreviousPeriodStart
 	}
 	earliestUTC := earliest.In(location).UTC()
+	// The comparison period only extends the window backwards (earliest), so the
+	// upper bound is still the report's end date.
+	until := reportUntil(query.EndDate, location)
 
-	entries, err := service.tracking.ListWorkspaceTimeEntries(ctx, query.WorkspaceID, &earliestUTC)
+	entries, err := service.tracking.ListWorkspaceTimeEntries(ctx, query.WorkspaceID, &earliestUTC, &until)
 	if err != nil {
 		return nil, err
 	}
@@ -508,7 +514,8 @@ func (service *Service) BuildProjectProfitability(ctx context.Context, query Pro
 
 	location := resolveLocation(query.Timezone)
 	startUTC := query.StartDate.In(location).UTC()
-	entries, err := service.tracking.ListWorkspaceTimeEntries(ctx, query.WorkspaceID, &startUTC)
+	until := reportUntil(query.EndDate, location)
+	entries, err := service.tracking.ListWorkspaceTimeEntries(ctx, query.WorkspaceID, &startUTC, &until)
 	if err != nil {
 		return nil, err
 	}
@@ -612,7 +619,8 @@ func (service *Service) BuildEmployeeProfitability(ctx context.Context, query Em
 
 	location := resolveLocation(query.Timezone)
 	startUTC := query.StartDate.In(location).UTC()
-	entries, err := service.tracking.ListWorkspaceTimeEntries(ctx, query.WorkspaceID, &startUTC)
+	until := reportUntil(query.EndDate, location)
+	entries, err := service.tracking.ListWorkspaceTimeEntries(ctx, query.WorkspaceID, &startUTC, &until)
 	if err != nil {
 		return nil, err
 	}
@@ -812,6 +820,17 @@ func inclusiveDayCount(startDate time.Time, endDate time.Time, location *time.Lo
 func normalizeToDay(value time.Time, location *time.Location) time.Time {
 	local := value.In(location)
 	return time.Date(local.Year(), local.Month(), local.Day(), 0, 0, 0, 0, location)
+}
+
+// reportUntil returns an exclusive UTC upper bound for a report's time-entry
+// scan. The Go-side day filter accepts an entry iff its local day is <= endDay,
+// i.e. its start_time is before the start of the day after endDay in the
+// report's location. This returns that boundary plus one day of buffer, so the
+// SQL bound is always a safe superset of what the Go filter keeps — the exact
+// per-day trimming still happens in Go, so a slightly wide bound never drops an
+// in-range entry, while an unbounded scan to now() is avoided.
+func reportUntil(endDate time.Time, location *time.Location) time.Time {
+	return normalizeToDay(endDate, location).AddDate(0, 0, 2).UTC()
 }
 
 func reportDayIndex(entry trackingapplication.TimeEntryView, query Query, location *time.Location) (int, bool) {

--- a/apps/backend/internal/reports/application/service_test.go
+++ b/apps/backend/internal/reports/application/service_test.go
@@ -2,11 +2,70 @@ package application
 
 import (
 	"testing"
+	"time"
 
 	trackingapplication "opentoggl/backend/apps/backend/internal/tracking/application"
 
 	"github.com/samber/lo"
 )
+
+// TestReportUntilIsSafeUpperBound guards the #2 report-scan optimization: the
+// SQL upper bound must never exclude an entry the Go-side day filter would keep.
+// The Go filter accepts an entry iff normalizeToDay(entry.Start) <= endDay, so
+// the last accepted instant is the final nanosecond of endDay in the report's
+// location. reportUntil must be strictly greater than that (in UTC) across
+// timezones and DST transitions.
+func TestReportUntilIsSafeUpperBound(t *testing.T) {
+	cases := []struct {
+		name string
+		tz   string
+		end  string
+	}{
+		{"utc", "UTC", "2026-05-07"},
+		{"positive offset (Tokyo)", "Asia/Tokyo", "2026-05-07"},
+		{"negative offset (New York)", "America/New_York", "2026-05-07"},
+		{"half-hour offset (India)", "Asia/Kolkata", "2026-05-07"},
+		{"US spring-forward DST edge", "America/New_York", "2026-03-08"},
+		{"US fall-back DST edge", "America/New_York", "2026-11-01"},
+		{"year end", "UTC", "2026-12-31"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			loc, err := time.LoadLocation(tc.tz)
+			if err != nil {
+				t.Fatalf("load location %q: %v", tc.tz, err)
+			}
+			endDate, err := time.ParseInLocation("2006-01-02", tc.end, loc)
+			if err != nil {
+				t.Fatalf("parse end date: %v", err)
+			}
+
+			until := reportUntil(endDate, loc)
+			endDay := normalizeToDay(endDate, loc)
+
+			// Last instant the Go filter accepts: 1ns before the start of the
+			// day after endDay, in the report's location.
+			lastAccepted := endDay.AddDate(0, 0, 1).Add(-time.Nanosecond)
+			if !lastAccepted.UTC().Before(until) {
+				t.Fatalf("until %v must be after last-accepted entry %v (tz=%s)",
+					until, lastAccepted.UTC(), tc.tz)
+			}
+
+			// A midday entry on endDay must be within the bound.
+			onEndDay := endDay.Add(12 * time.Hour)
+			if !onEndDay.UTC().Before(until) {
+				t.Fatalf("until %v must include a same-day entry %v (tz=%s)",
+					until, onEndDay.UTC(), tc.tz)
+			}
+
+			// The bound stays reasonably tight (never more than ~2 days past
+			// endDay), so it does not reintroduce an unbounded scan.
+			if until.After(endDay.AddDate(0, 0, 3).UTC()) {
+				t.Fatalf("until %v is too far past endDay %v (tz=%s)", until, endDay, tc.tz)
+			}
+		})
+	}
+}
 
 // entryWith builds a TimeEntryView with only the fields matchesQueryFilters
 // inspects.

--- a/apps/backend/internal/tracking/application/recent_suggestions_window_test.go
+++ b/apps/backend/internal/tracking/application/recent_suggestions_window_test.go
@@ -1,0 +1,72 @@
+package application_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"opentoggl/backend/apps/backend/internal/testsupport/pgtest"
+	trackingapplication "opentoggl/backend/apps/backend/internal/tracking/application"
+)
+
+// TestRecentSuggestionsRespect90DayWindow guards the #5 optimization: the
+// recent-suggestions query bounds its window function to the last 90 days, so a
+// long-dormant reusable entry must not surface while a recent one does.
+func TestRecentSuggestionsRespect90DayWindow(t *testing.T) {
+	database := pgtest.Open(t)
+	ctx := context.Background()
+
+	workspaceID, userID := seedTrackingWorkspaceWithUniqueEmail(t, ctx, database, "recent-window")
+	catalogService := mustNewTrackingCatalogService(t, database)
+	trackingService := mustNewTrackingService(t, database, catalogService, testLogger)
+
+	const oldDescription = "Dormant task older than the window"
+	const recentDescription = "Task within the window"
+
+	oldStart := time.Now().UTC().Add(-120 * 24 * time.Hour)
+	oldStop := oldStart.Add(30 * time.Minute)
+	if _, err := trackingService.CreateTimeEntry(ctx, trackingapplication.CreateTimeEntryCommand{
+		WorkspaceID: workspaceID,
+		UserID:      userID,
+		Description: oldDescription,
+		Start:       oldStart,
+		Stop:        &oldStop,
+		CreatedWith: "recent-window-test",
+	}); err != nil {
+		t.Fatalf("create old entry: %v", err)
+	}
+
+	recentStart := time.Now().UTC().Add(-2 * 24 * time.Hour)
+	recentStop := recentStart.Add(30 * time.Minute)
+	if _, err := trackingService.CreateTimeEntry(ctx, trackingapplication.CreateTimeEntryCommand{
+		WorkspaceID: workspaceID,
+		UserID:      userID,
+		Description: recentDescription,
+		Start:       recentStart,
+		Stop:        &recentStop,
+		CreatedWith: "recent-window-test",
+	}); err != nil {
+		t.Fatalf("create recent entry: %v", err)
+	}
+
+	suggestions, err := trackingService.ListRecentTimeEntrySuggestions(ctx, workspaceID, userID, 8)
+	if err != nil {
+		t.Fatalf("list recent suggestions: %v", err)
+	}
+
+	var sawRecent, sawOld bool
+	for _, s := range suggestions {
+		switch s.Description {
+		case recentDescription:
+			sawRecent = true
+		case oldDescription:
+			sawOld = true
+		}
+	}
+	if !sawRecent {
+		t.Fatalf("expected recent entry within the 90-day window to be suggested, got %+v", suggestions)
+	}
+	if sawOld {
+		t.Fatalf("entry older than 90 days must be excluded from suggestions, got %+v", suggestions)
+	}
+}

--- a/apps/backend/internal/tracking/application/service_dashboard.go
+++ b/apps/backend/internal/tracking/application/service_dashboard.go
@@ -10,11 +10,12 @@ func (service *Service) ListWorkspaceTimeEntries(
 	ctx context.Context,
 	workspaceID int64,
 	since *time.Time,
+	until *time.Time,
 ) ([]TimeEntryView, error) {
 	if err := requireWorkspaceID(workspaceID); err != nil {
 		return nil, err
 	}
-	return service.store.ListWorkspaceTimeEntries(ctx, workspaceID, since)
+	return service.store.ListWorkspaceTimeEntries(ctx, workspaceID, since, until)
 }
 
 func (service *Service) ListWorkspaceDashboardActivities(
@@ -25,7 +26,7 @@ func (service *Service) ListWorkspaceDashboardActivities(
 	if err := requireWorkspaceID(workspaceID); err != nil {
 		return nil, err
 	}
-	entries, err := service.store.ListWorkspaceTimeEntries(ctx, workspaceID, since)
+	entries, err := service.store.ListWorkspaceTimeEntries(ctx, workspaceID, since, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +55,7 @@ func (service *Service) ListWorkspaceTopActivities(
 	if err := requireWorkspaceID(workspaceID); err != nil {
 		return nil, err
 	}
-	entries, err := service.store.ListWorkspaceTimeEntries(ctx, workspaceID, since)
+	entries, err := service.store.ListWorkspaceTimeEntries(ctx, workspaceID, since, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +96,7 @@ func (service *Service) ListWorkspaceMostActiveUsers(
 		defaultSince := service.now().Add(-7 * 24 * time.Hour)
 		since = &defaultSince
 	}
-	entries, err := service.store.ListWorkspaceTimeEntries(ctx, workspaceID, since)
+	entries, err := service.store.ListWorkspaceTimeEntries(ctx, workspaceID, since, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/backend/internal/tracking/application/types.go
+++ b/apps/backend/internal/tracking/application/types.go
@@ -305,7 +305,7 @@ type Store interface {
 	ListTimeEntriesForUser(context.Context, ListTimeEntriesFilter) ([]TimeEntryView, error)
 	SearchTimeEntries(context.Context, int64, int64, string) ([]TimeEntrySearchView, error)
 	ListRecentTimeEntrySuggestions(context.Context, int64, int64, int) ([]TimeEntrySearchView, error)
-	ListWorkspaceTimeEntries(context.Context, int64, *time.Time) ([]TimeEntryView, error)
+	ListWorkspaceTimeEntries(context.Context, int64, *time.Time, *time.Time) ([]TimeEntryView, error)
 	GetCurrentTimeEntry(context.Context, int64) (TimeEntryView, bool, error)
 	UpdateTimeEntry(context.Context, UpdateTimeEntryRecord) (TimeEntryView, error)
 	DeleteTimeEntry(context.Context, int64, int64, int64) error

--- a/apps/backend/internal/tracking/infra/postgres/store_time_entries.go
+++ b/apps/backend/internal/tracking/infra/postgres/store_time_entries.go
@@ -417,6 +417,10 @@ func (store *Store) ListRecentTimeEntrySuggestions(
 		  and te.user_id = $2
 		  and te.deleted_at is null
 		  and te.stop_time is not null
+		  -- Bound the window function to recent history so this endpoint (polled
+		  -- every 30s by the timer bar) does not rank a long-tenured user's entire
+		  -- lifetime of entries. Rides (workspace_id, user_id, start_time).
+		  and te.start_time >= now() - interval '90 days'
 	)
 	select
 		id,
@@ -474,6 +478,7 @@ func (store *Store) ListWorkspaceTimeEntries(
 	ctx context.Context,
 	workspaceID int64,
 	since *time.Time,
+	until *time.Time,
 ) ([]trackingapplication.TimeEntryView, error) {
 	query := `select
 		te.id,
@@ -508,6 +513,10 @@ func (store *Store) ListWorkspaceTimeEntries(
 	if since != nil {
 		args = append(args, since.UTC())
 		query += " and te.start_time >= $" + intParam(len(args))
+	}
+	if until != nil {
+		args = append(args, until.UTC())
+		query += " and te.start_time < $" + intParam(len(args))
 	}
 	query += " order by te.start_time desc, te.id desc"
 


### PR DESCRIPTION
## What this is

The two behavior-sensitive scalability findings deferred from #55, now implemented with test coverage. Both bound previously-unbounded `tracking_time_entries` scans.

## #2 — Reports over-fetch pushdown

Every report builder called `ListWorkspaceTimeEntries` with only a **start** bound, so a report for one past week still scanned every workspace entry from the range start **to `now()`** (3 joins + a per-row tag subquery) and discarded the vast majority in Go.

- Added a nullable `until *time.Time` upper bound to the store method; the query now adds `and te.start_time < $until`.
- All 5 report call sites pass `reportUntil(query.EndDate, location)`. `reportUntil` returns the start of the day **after** `endDay` in the report's location, **+ 1 day of buffer**, converted to UTC — a provably safe **superset** of what the Go day-filter keeps. The exact per-day trimming still happens in Go, so **no boundary entry is ever dropped**, while the scan is bounded to the report window.
- The 4 dashboard callers pass `nil` (behavior unchanged — they want up to now).
- **Test:** `TestReportUntilIsSafeUpperBound` asserts the bound is strictly after the last Go-accepted instant across UTC, positive/negative/half-hour offsets, and both US DST transitions.

## #5 — recent-suggestions window

`ListRecentTimeEntrySuggestions` ran a `row_number()` window function over a user's **entire lifetime** of stopped entries on every timer-bar load (**polled every 30s**).

- Bounded the CTE input to the last **90 days** before ranking; rides the `(workspace_id, user_id, start_time)` index added in #55.
- **Test:** `TestRecentSuggestionsRespect90DayWindow` (pgtest, CI-covered) — a >90-day entry is excluded, a recent one is kept.

> [!NOTE]
> #5 narrows a previously-unbounded "recent" window. The openapi contract (`opentoggl-web.openapi.json`) does not define a window for "recent", so this is a deliberate behavior change: an entry not logged in **>90 days** no longer surfaces as a reuse suggestion. The window is a single named bound, easy to tune. Flagging explicitly for product review.

## Verification
- Full backend test suite (CI's list) green against Postgres 17, including both new tests.
- `go vet` clean; the signature change propagated across all call sites + the embedded cache decorator with no other edits.
- Only the `until` upper bound is pushed to SQL for #2 — pushing the project/user/billable filters into the WHERE clause is a possible further follow-up, intentionally not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
