### PR TITLE
fix(landing): repair build (react-router 8.2.0) + apply held perf optimizations

### DIFF
--- a/Dockerfile.landing
+++ b/Dockerfile.landing
@@ -1,7 +1,7 @@
 # Force the builder stage to run natively on the CI runner arch (amd64 on GH hosted),
 # so pnpm install + vite build aren't executed under QEMU arm64 emulation (30min+ -> ~3min).
 # Output is a plain dist/ (static files), copied into the TARGETPLATFORM runtime image below.
-FROM --platform=$BUILDPLATFORM node:22.12.0-bookworm-slim AS builder
+FROM --platform=$BUILDPLATFORM node:24-bookworm-slim AS builder
 
 WORKDIR /workspace
 
@@ -9,16 +9,34 @@ RUN npm install -g pnpm@10.32.1
 
 # Copy workspace scaffolding
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json ./
+
+# Manifests-first: copy every workspace member's package.json so pnpm can resolve
+# the full graph, keeping the install layer cached across source-only edits.
+COPY apps/landing/package.json ./apps/landing/
+COPY apps/website/package.json ./apps/website/
+COPY apps/update-worker/package.json ./apps/update-worker/
+COPY packages/web-ui/package.json ./packages/web-ui/
+COPY packages/shared-contracts/package.json ./packages/shared-contracts/
+
+RUN pnpm install --filter @opentickly/landing... --no-frozen-lockfile --ignore-scripts
+
 COPY apps/landing ./apps/landing
 COPY packages ./packages
 
-RUN pnpm install --filter @opentickly/landing... --no-frozen-lockfile --ignore-scripts
-RUN pnpm --filter @opentickly/landing run postinstall
+# react-router's prerender step starts a Vite preview server and reaches it over
+# node:http. Under Node 24 the server binds localhost to ::1 while the client
+# dials 127.0.0.1, so prerender fails with ECONNREFUSED. Force IPv4-first
+# resolution so both ends agree on the loopback address.
+ENV NODE_OPTIONS="--dns-result-order=ipv4first"
+
+# The build script runs fumadocs-mdx before react-router build, so it
+# regenerates .source itself — no separate postinstall pass needed (install
+# ran with --ignore-scripts).
 RUN pnpm --filter @opentickly/landing run build
 
 # ---
 
-FROM node:22.12.0-bookworm-slim
+FROM node:24-bookworm-slim
 
 RUN npm install -g serve@14
 

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -20,7 +20,7 @@
     "fumadocs-core": "16.11.5",
     "fumadocs-mdx": "15.2.0",
     "fumadocs-ui": "16.11.5",
-    "isbot": "^5.2.1",
+    "isbot": "^5",
     "lucide-react": "catalog:",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",

--- a/apps/landing/react-router.config.ts
+++ b/apps/landing/react-router.config.ts
@@ -5,9 +5,6 @@ import { i18n } from "./app/lib/i18n";
 
 export default {
   ssr: false,
-  future: {
-    v8_middleware: true,
-  },
   async prerender({ getStaticPaths }) {
     const paths: string[] = ["/robots.txt", "/sitemap.xml"];
     const excluded: string[] = [];

--- a/apps/landing/scripts/optimize-images.mjs
+++ b/apps/landing/scripts/optimize-images.mjs
@@ -1,3 +1,4 @@
+import { existsSync, statSync } from "node:fs";
 import { readdir } from "node:fs/promises";
 import { join } from "node:path";
 import sharp from "sharp";
@@ -5,21 +6,43 @@ import sharp from "sharp";
 const heroDir = new URL("../public/hero", import.meta.url).pathname;
 const widths = [640, 960, 1280];
 
+const isUpToDate = (input, output) =>
+  existsSync(output) && statSync(output).mtimeMs >= statSync(input).mtimeMs;
+
 const files = await readdir(heroDir);
 const pngs = files.filter((f) => f.endsWith(".png"));
+
+let encoded = 0;
+let skipped = 0;
 
 for (const png of pngs) {
   const input = join(heroDir, png);
   const baseWebp = png.replace(/\.png$/, ".webp");
-  await sharp(input).webp({ quality: 82 }).toFile(join(heroDir, baseWebp));
-  console.log(`${png} -> ${baseWebp}`);
+  const baseOutput = join(heroDir, baseWebp);
+  if (isUpToDate(input, baseOutput)) {
+    skipped++;
+    console.log(`${png} -> ${baseWebp} (skipped, up to date)`);
+  } else {
+    await sharp(input).webp({ quality: 82 }).toFile(baseOutput);
+    encoded++;
+    console.log(`${png} -> ${baseWebp}`);
+  }
 
   for (const width of widths) {
-    const output = png.replace(/\.png$/, `-${width}.webp`);
-    await sharp(input)
-      .resize({ width, withoutEnlargement: true })
-      .webp({ quality: 78 })
-      .toFile(join(heroDir, output));
-    console.log(`${png} -> ${output}`);
+    const outputName = png.replace(/\.png$/, `-${width}.webp`);
+    const output = join(heroDir, outputName);
+    if (isUpToDate(input, output)) {
+      skipped++;
+      console.log(`${png} -> ${outputName} (skipped, up to date)`);
+    } else {
+      await sharp(input)
+        .resize({ width, withoutEnlargement: true })
+        .webp({ quality: 78 })
+        .toFile(output);
+      encoded++;
+      console.log(`${png} -> ${outputName}`);
+    }
   }
 }
+
+console.log(`Images: ${encoded} encoded, ${skipped} skipped.`);

--- a/apps/landing/serve.json
+++ b/apps/landing/serve.json
@@ -1,4 +1,33 @@
 {
   "cleanUrls": true,
-  "trailingSlash": false
+  "trailingSlash": false,
+  "headers": [
+    {
+      "source": "assets/**",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "hero/**",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=86400, stale-while-revalidate=604800"
+        }
+      ]
+    },
+    {
+      "source": "**/*.html",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-cache"
+        }
+      ]
+    }
+  ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,7 +172,7 @@ importers:
         specifier: 16.11.5
         version: 16.11.5(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.11.5(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.25.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react-router@8.2.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(zod@4.4.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.3)
       isbot:
-        specifier: ^5.2.1
+        specifier: ^5
         version: 5.2.1
       lucide-react:
         specifier: 'catalog:'


### PR DESCRIPTION
## Why

The `apps/landing` build was **broken on `main`**. The dependabot bump of `@react-router/dev` to **8.2.0** broke it two ways:

1. **Removed config flag** — 8.2.0 dropped the `future.v8_middleware` flag (middleware is always-on now), but `apps/landing/react-router.config.ts` still set `v8_middleware: true`, so `react-router typegen` hard-errors (`TS2353: 'v8_middleware' does not exist in type 'Partial<FutureConfig>'`).
2. **Raised the Node floor** — 8.2.0 requires Node **> 22.22.0**, but `Dockerfile.landing` pinned `node:22.12.0-bookworm-slim`, so react-router's `resolveEntryFiles` Node gate fails during the build.

Per the repo owner's decision, the fix is to **upgrade Node**, not downgrade react-router.

## What

### Build repair
- **Remove the `future.v8_middleware` block** from `react-router.config.ts`.
- **Bump the Docker base image to `node:24-bookworm-slim`** in both the builder and runtime stages of `Dockerfile.landing` (Node 24 LTS, unambiguously > 22.22.0; the runtime stage only runs `serve`).

### Two further fixes surfaced once the build got past those blockers

- ⚠️ **`isbot` was NOT removed — it is required, not unused.** The held plan called for removing `isbot`, but that is wrong: react-router 8.2.0's **default server entry imports `isbot`**, and when it is absent from `package.json`, `resolveEntryFiles` runs `npm install isbot`, which fails on the `workspace:` protocol — breaking both `react-router typegen` and the Docker build. react-router's own tooling even auto-re-adds it (`adding isbot@5 to your package.json, you should commit this change`). Grep missed it because the import lives in a virtual module. **Resolution: keep `isbot`, loosen `^5.2.1` → `^5`** (the exact constraint react-router auto-adds). Note: the held patch itself never removed isbot — it too only loosened the constraint.
- ⚠️ **Prerender loopback fix (beyond the originally-anticipated scope).** Once the earlier blockers were cleared, react-router's prerender step — newly reachable — failed with `connect ECONNREFUSED 127.0.0.1`. It starts a Vite preview server and reaches it over `node:http`, but under Node 24 the server binds `localhost` to `::1` while the client dials `127.0.0.1`. Fixed by setting `NODE_OPTIONS=--dns-result-order=ipv4first` in the builder stage so both ends agree on the loopback address.

### Held perf optimizations
- **`serve.json`** — `Cache-Control` headers: hashed `assets/**` → `public, max-age=31536000, immutable`; non-hashed `hero/**` → `public, max-age=86400, stale-while-revalidate=604800` (revalidating, **not** immutable, so updated hero art propagates); HTML → `no-cache`.
- **`optimize-images.mjs`** — mtime gate skips re-encoding hero WebP that is already up to date, avoiding redundant `sharp` work every build.
- **`Dockerfile.landing`** — manifests-first COPY (copy each workspace member's `package.json` before `pnpm install`) so the install layer stays cached across source-only edits; drop the now-redundant standalone `postinstall` run (the build script already runs `fumadocs-mdx` before `react-router build`, regenerating `.source`).
- **`package.json`** — loosen the `isbot` constraint (see above).

## Verification

- ✅ **Full Docker build passes:** `docker build -f Dockerfile.landing -t landing-verify .` → **exit 0** (~11s with the install layer cached). Runs `react-router build` under node:24 end-to-end and **prerenders all 60 pages** (robots, sitemap, `api/search`, `llms.txt`/`ai.txt` + i18n variants, docs), then `postbuild`, then exports the image. Both a full build without the prerender fix and with `isbot` removed were reproduced as failures first, confirming each fix is load-bearing.
- ✅ **`vp check`:** the previously-failing `v8_middleware` error (TS2353) is **gone**. The only remaining 2 errors are pre-existing and unrelated (`apps/update-worker/src/content.ts` referencing an ungenerated `content.generated.ts` — present on `main` too, in a file this PR does not touch). Confirmed via a stash A/B: `main` reports 3 errors (incl. `v8_middleware`), this branch reports 2 (only the update-worker pair) — zero new errors introduced.
- ✅ **`vp run landing#check`** (runs the real `react-router typegen`) passes clean.

## Scope

Only `apps/landing` needs the Node bump (it uses react-router; the website does not). The website Dockerfile and CI Node versions are untouched. Root `engines.node` (`>=22.12.0`) is a floor, not a ceiling, and does not block — left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
