### PR TITLE
fix(tracking): match Toggl's bulk time-entry patch contract

### DIFF
--- a/apps/backend/internal/catalog/application/service_tags.go
+++ b/apps/backend/internal/catalog/application/service_tags.go
@@ -67,6 +67,44 @@ func (service *Service) EnsureTagsByName(ctx context.Context, workspaceID int64,
 	return service.store.EnsureTagsByName(ctx, workspaceID, createdBy, names)
 }
 
+// ResolveTagIDsByName maps existing tag names to ids without creating anything.
+// Names that do not exist in the workspace are skipped: removing a tag nobody
+// has is a no-op, not an error, and a `remove` op must never create the tag it
+// is trying to drop.
+func (service *Service) ResolveTagIDsByName(ctx context.Context, workspaceID int64, names []string) ([]int64, error) {
+	if err := requireWorkspaceID(workspaceID); err != nil {
+		return nil, err
+	}
+	wanted := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		trimmed := strings.TrimSpace(name)
+		if trimmed == "" {
+			continue
+		}
+		wanted[strings.ToLower(trimmed)] = struct{}{}
+	}
+	if len(wanted) == 0 {
+		return nil, nil
+	}
+
+	ids := make([]int64, 0, len(wanted))
+	const perPage = 200
+	for page := 1; ; page++ {
+		tags, err := service.ListTags(ctx, workspaceID, ListTagsFilter{Page: page, PerPage: perPage})
+		if err != nil {
+			return nil, err
+		}
+		for _, tag := range tags {
+			if _, ok := wanted[strings.ToLower(tag.Name)]; ok {
+				ids = append(ids, tag.ID)
+			}
+		}
+		if len(tags) < perPage {
+			return ids, nil
+		}
+	}
+}
+
 func (service *Service) GetTag(ctx context.Context, workspaceID int64, tagID int64) (TagView, error) {
 	if err := requireWorkspaceID(workspaceID); err != nil {
 		return TagView{}, err

--- a/apps/backend/internal/tracking/application/bulk_patch_fields_test.go
+++ b/apps/backend/internal/tracking/application/bulk_patch_fields_test.go
@@ -2,6 +2,7 @@ package application_test
 
 import (
 	"context"
+	"slices"
 	"testing"
 	"time"
 
@@ -69,7 +70,7 @@ func TestPatchTimeEntries_AppliesProjectAndTagIDs(t *testing.T) {
 		entryIDs = append(entryIDs, entry.ID)
 	}
 
-	success, err := trackingService.PatchTimeEntries(ctx, trackingapplication.PatchTimeEntriesCommand{
+	success, failures, err := trackingService.PatchTimeEntries(ctx, trackingapplication.PatchTimeEntriesCommand{
 		WorkspaceID:  workspaceID,
 		UserID:       userID,
 		TimeEntryIDs: entryIDs,
@@ -80,6 +81,9 @@ func TestPatchTimeEntries_AppliesProjectAndTagIDs(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("patch time entries: %v", err)
+	}
+	if len(failures) != 0 {
+		t.Fatalf("expected no failures, got %+v", failures)
 	}
 	if len(success) != len(entryIDs) {
 		t.Fatalf("expected %d success IDs, got %d", len(entryIDs), len(success))
@@ -142,7 +146,7 @@ func TestPatchTimeEntries_ClearsProjectWhenIDZero(t *testing.T) {
 		t.Fatalf("create entry: %v", err)
 	}
 
-	if _, err := trackingService.PatchTimeEntries(ctx, trackingapplication.PatchTimeEntriesCommand{
+	if _, _, err := trackingService.PatchTimeEntries(ctx, trackingapplication.PatchTimeEntriesCommand{
 		WorkspaceID:  workspaceID,
 		UserID:       userID,
 		TimeEntryIDs: []int64{entry.ID},
@@ -157,5 +161,140 @@ func TestPatchTimeEntries_ClearsProjectWhenIDZero(t *testing.T) {
 	}
 	if readback.ProjectID != nil {
 		t.Fatalf("expected project cleared, got %v", *readback.ProjectID)
+	}
+}
+
+// TestPatchTimeEntries_AddAndRemoveTagsAreIncremental pins Toggl's semantics for
+// the `add` and `remove` ops on /tags: unlike `replace`, they must leave the
+// tags an entry already carries alone.
+func TestPatchTimeEntries_AddAndRemoveTagsAreIncremental(t *testing.T) {
+	database := pgtest.Open(t)
+	ctx := context.Background()
+
+	workspaceID, userID := seedTrackingWorkspaceWithUniqueEmail(t, ctx, database, "bulk-patch-tag-ops")
+	catalogService := mustNewTrackingCatalogService(t, database)
+	trackingService := mustNewTrackingService(t, database, catalogService, testLogger)
+
+	keep, err := catalogService.CreateTag(ctx, catalogapplication.CreateTagCommand{
+		WorkspaceID: workspaceID,
+		CreatedBy:   userID,
+		Name:        "KeepTag",
+	})
+	if err != nil {
+		t.Fatalf("create keep tag: %v", err)
+	}
+	added, err := catalogService.CreateTag(ctx, catalogapplication.CreateTagCommand{
+		WorkspaceID: workspaceID,
+		CreatedBy:   userID,
+		Name:        "AddedTag",
+	})
+	if err != nil {
+		t.Fatalf("create added tag: %v", err)
+	}
+
+	start := time.Date(2026, 4, 3, 9, 0, 0, 0, time.UTC)
+	stop := start.Add(time.Hour)
+	entry, err := trackingService.CreateTimeEntry(ctx, trackingapplication.CreateTimeEntryCommand{
+		WorkspaceID: workspaceID,
+		UserID:      userID,
+		Description: "tag ops",
+		Start:       start,
+		Stop:        &stop,
+		TagIDs:      []int64{keep.ID},
+		CreatedWith: "bulk-patch-tag-ops-test",
+	})
+	if err != nil {
+		t.Fatalf("create entry: %v", err)
+	}
+
+	if _, _, err := trackingService.PatchTimeEntries(ctx, trackingapplication.PatchTimeEntriesCommand{
+		WorkspaceID:  workspaceID,
+		UserID:       userID,
+		TimeEntryIDs: []int64{entry.ID},
+		AddTagIDs:    []int64{added.ID},
+	}); err != nil {
+		t.Fatalf("add tag patch: %v", err)
+	}
+
+	readback, err := trackingService.GetTimeEntry(ctx, workspaceID, userID, entry.ID)
+	if err != nil {
+		t.Fatalf("readback after add: %v", err)
+	}
+	if !slices.Contains(readback.TagIDs, keep.ID) {
+		t.Fatalf("add op dropped the pre-existing tag: %v", readback.TagIDs)
+	}
+	if !slices.Contains(readback.TagIDs, added.ID) {
+		t.Fatalf("add op did not add the requested tag: %v", readback.TagIDs)
+	}
+
+	if _, _, err := trackingService.PatchTimeEntries(ctx, trackingapplication.PatchTimeEntriesCommand{
+		WorkspaceID:  workspaceID,
+		UserID:       userID,
+		TimeEntryIDs: []int64{entry.ID},
+		RemoveTagIDs: []int64{added.ID},
+	}); err != nil {
+		t.Fatalf("remove tag patch: %v", err)
+	}
+
+	readback, err = trackingService.GetTimeEntry(ctx, workspaceID, userID, entry.ID)
+	if err != nil {
+		t.Fatalf("readback after remove: %v", err)
+	}
+	if slices.Contains(readback.TagIDs, added.ID) {
+		t.Fatalf("remove op left the tag in place: %v", readback.TagIDs)
+	}
+	if !slices.Contains(readback.TagIDs, keep.ID) {
+		t.Fatalf("remove op dropped an unrelated tag: %v", readback.TagIDs)
+	}
+}
+
+// TestPatchTimeEntries_ReportsMissingEntriesAsFailures pins the non-transactional
+// contract: a bad id lands in the failure list while the good ids still apply,
+// instead of aborting the batch or being reported as a success.
+func TestPatchTimeEntries_ReportsMissingEntriesAsFailures(t *testing.T) {
+	database := pgtest.Open(t)
+	ctx := context.Background()
+
+	workspaceID, userID := seedTrackingWorkspaceWithUniqueEmail(t, ctx, database, "bulk-patch-failures")
+	catalogService := mustNewTrackingCatalogService(t, database)
+	trackingService := mustNewTrackingService(t, database, catalogService, testLogger)
+
+	start := time.Date(2026, 4, 4, 9, 0, 0, 0, time.UTC)
+	stop := start.Add(time.Hour)
+	entry, err := trackingService.CreateTimeEntry(ctx, trackingapplication.CreateTimeEntryCommand{
+		WorkspaceID: workspaceID,
+		UserID:      userID,
+		Description: "before",
+		Start:       start,
+		Stop:        &stop,
+		CreatedWith: "bulk-patch-failures-test",
+	})
+	if err != nil {
+		t.Fatalf("create entry: %v", err)
+	}
+
+	const missingID int64 = 999_999_999
+	success, failures, err := trackingService.PatchTimeEntries(ctx, trackingapplication.PatchTimeEntriesCommand{
+		WorkspaceID:  workspaceID,
+		UserID:       userID,
+		TimeEntryIDs: []int64{missingID, entry.ID},
+		Description:  lo.ToPtr("after"),
+	})
+	if err != nil {
+		t.Fatalf("patch time entries: %v", err)
+	}
+	if !slices.Equal(success, []int64{entry.ID}) {
+		t.Fatalf("expected only the real entry to succeed, got %v", success)
+	}
+	if len(failures) != 1 || failures[0].ID != missingID {
+		t.Fatalf("expected the missing id in the failure list, got %+v", failures)
+	}
+
+	readback, err := trackingService.GetTimeEntry(ctx, workspaceID, userID, entry.ID)
+	if err != nil {
+		t.Fatalf("readback: %v", err)
+	}
+	if readback.Description != "after" {
+		t.Fatalf("expected the valid entry to still be patched, got %q", readback.Description)
 	}
 }

--- a/apps/backend/internal/tracking/application/security_regressions_test.go
+++ b/apps/backend/internal/tracking/application/security_regressions_test.go
@@ -3,6 +3,8 @@ package application_test
 import (
 	"context"
 	"fmt"
+	"slices"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -744,21 +746,26 @@ func TestSameWorkspaceUserACannotPatchUserBTimeEntries(t *testing.T) {
 	attackerPatchDescription := "Attacker patched description"
 
 	// Call PatchTimeEntries with user A's userID but targeting user B's entry IDs.
-	// This tests whether the batch operation partially applies to user A's own entry
-	// while denying user B's entries, or whether it fails atomically.
-	_, err = trackingService.PatchTimeEntries(ctx, trackingapplication.PatchTimeEntriesCommand{
+	// The batch is partial by contract, so user A's own entry may be patched;
+	// what must never happen is user B's entry being touched.
+	success, failures, err := trackingService.PatchTimeEntries(ctx, trackingapplication.PatchTimeEntriesCommand{
 		WorkspaceID:  workspaceID,
 		UserID:       ownerID,
 		TimeEntryIDs: []int64{memberEntry1.ID, ownerEntry.ID},
 		Description:  &attackerPatchDescription,
 	})
+	if err != nil {
+		t.Fatalf("PatchTimeEntries should report per-entry denial, not a call error: %v", err)
+	}
 
-	// PatchTimeEntries calls UpdateTimeEntry for each ID in sequence.
-	// If it hits user B's entry first, UpdateTimeEntry will return ErrTimeEntryNotFound
-	// (because userID=ownerID doesn't match user B's entry owner), and the batch stops.
-	// Either the entire batch fails, or it must not partially apply.
-	if err != nil && err != trackingapplication.ErrTimeEntryNotFound {
-		t.Fatalf("PatchTimeEntries with mixed attacker/target IDs should return error, got: %v", err)
+	// User B's entry must be reported as a failure and must never appear as a success.
+	if slices.Contains(success, memberEntry1.ID) {
+		t.Fatalf("VAL-SEC-TRACK-004: user B's entry %d was reported as successfully patched", memberEntry1.ID)
+	}
+	if !slices.ContainsFunc(failures, func(failure trackingapplication.PatchTimeEntryFailure) bool {
+		return failure.ID == memberEntry1.ID
+	}) {
+		t.Fatalf("VAL-SEC-TRACK-004: user B's entry %d missing from failure list: %+v", memberEntry1.ID, failures)
 	}
 
 	// VAL-SEC-TRACK-004 core assertion: direct readback of ALL targeted user B entries
@@ -790,7 +797,10 @@ func TestSameWorkspaceUserACannotPatchUserBTimeEntries(t *testing.T) {
 		t.Fatalf("VAL-SEC-TRACK-004: user B should still have exactly 2 entries, got %d", len(memberEntries))
 	}
 
-	// Verify user A's own entry is also intact (batch didn't partially apply to anything)
+	// User A's own entry may be patched: the batch is partial by contract, and
+	// editing their own entry is something user A can do anyway. The security
+	// property under test is that user B's entries are untouched (asserted
+	// above), not that a mixed batch is rejected wholesale.
 	ownerReadback, err := trackingService.GetTimeEntry(ctx, workspaceID, ownerID, ownerEntry.ID)
 	if err != nil {
 		t.Fatalf("user A direct readback of own entry after denied patch: %v", err)
@@ -798,10 +808,8 @@ func TestSameWorkspaceUserACannotPatchUserBTimeEntries(t *testing.T) {
 	if ownerReadback.ID != ownerEntry.ID {
 		t.Fatalf("user A's own entry ID changed; expected %d, got %d", ownerEntry.ID, ownerReadback.ID)
 	}
-	// Note: If the patch was partially applied to ownerEntry before failing on memberEntry1,
-	// ownerReadback.Description would be attackerPatchDescription. We check this is NOT the case.
-	if ownerReadback.Description == attackerPatchDescription {
-		t.Fatalf("VAL-SEC-TRACK-004: user A's own entry was partially mutated by failed batch; description changed to attacker value %q", attackerPatchDescription)
+	if !slices.Contains(success, ownerEntry.ID) {
+		t.Fatalf("user A's own entry %d should still be patched in a partial batch, got success %v", ownerEntry.ID, success)
 	}
 }
 
@@ -1035,19 +1043,27 @@ func TestSameWorkspaceBatchMutationExcludesUnauthorizedEntries(t *testing.T) {
 	attackerPatchDescription := "Attacker patched"
 
 	// Call PatchTimeEntries targeting only user B's entries with user A's userID
-	_, err = trackingService.PatchTimeEntries(ctx, trackingapplication.PatchTimeEntriesCommand{
+	success, failures, err := trackingService.PatchTimeEntries(ctx, trackingapplication.PatchTimeEntriesCommand{
 		WorkspaceID:  workspaceID,
 		UserID:       ownerID,
 		TimeEntryIDs: []int64{memberEntry1.ID, memberEntry2.ID},
 		Description:  &attackerPatchDescription,
 	})
-
-	// The batch must be denied - all targeted entries belong to user B
-	if err == nil {
-		t.Fatalf("PatchTimeEntries with only unauthorized targets should return error, got nil")
+	if err != nil {
+		t.Fatalf("PatchTimeEntries should report per-entry denial, not a call error: %v", err)
 	}
-	if err != trackingapplication.ErrTimeEntryNotFound {
-		t.Fatalf("expected ErrTimeEntryNotFound for unauthorized batch, got: %v", err)
+
+	// Every targeted entry belongs to user B, so nothing may be reported as patched.
+	if len(success) != 0 {
+		t.Fatalf("PatchTimeEntries with only unauthorized targets reported successes: %v", success)
+	}
+	if len(failures) != 2 {
+		t.Fatalf("expected both unauthorized entries in the failure list, got: %+v", failures)
+	}
+	for _, failure := range failures {
+		if !strings.Contains(failure.Message, trackingapplication.ErrTimeEntryNotFound.Error()) {
+			t.Fatalf("expected not-found reason for unauthorized entry %d, got: %q", failure.ID, failure.Message)
+		}
 	}
 
 	// VAL-SEC-TRACK-004 core assertion: NO partial mutation on ANY targeted entry.

--- a/apps/backend/internal/tracking/application/service_time_entry_mutations.go
+++ b/apps/backend/internal/tracking/application/service_time_entry_mutations.go
@@ -2,6 +2,7 @@ package application
 
 import (
 	"context"
+	"slices"
 	"strings"
 
 	"opentoggl/backend/apps/backend/internal/xptr"
@@ -72,6 +73,18 @@ func (service *Service) UpdateTimeEntry(ctx context.Context, command UpdateTimeE
 	}
 	if command.ReplaceTags {
 		current.TagIDs = append([]int64(nil), command.TagIDs...)
+	}
+	if len(command.AddTagIDs) > 0 {
+		for _, tagID := range command.AddTagIDs {
+			if !slices.Contains(current.TagIDs, tagID) {
+				current.TagIDs = append(current.TagIDs, tagID)
+			}
+		}
+	}
+	if len(command.RemoveTagIDs) > 0 {
+		current.TagIDs = lo.Filter(current.TagIDs, func(tagID int64, _ int) bool {
+			return !slices.Contains(command.RemoveTagIDs, tagID)
+		})
 	}
 
 	start := current.Start
@@ -157,29 +170,45 @@ func (service *Service) UpdateTimeEntry(ctx context.Context, command UpdateTimeE
 	return updated, nil
 }
 
-func (service *Service) PatchTimeEntries(ctx context.Context, command PatchTimeEntriesCommand) ([]int64, error) {
+// PatchTimeEntries applies one patch to every requested entry. Per Toggl's
+// contract the operation is partial: an entry that cannot be updated is
+// reported in the failure list and the remaining entries are still applied.
+// Only an infrastructure-level problem aborts the whole call.
+func (service *Service) PatchTimeEntries(
+	ctx context.Context,
+	command PatchTimeEntriesCommand,
+) ([]int64, []PatchTimeEntryFailure, error) {
 	success := make([]int64, 0, len(command.TimeEntryIDs))
+	failures := make([]PatchTimeEntryFailure, 0)
 	for _, timeEntryID := range command.TimeEntryIDs {
 		update := UpdateTimeEntryCommand{
-			WorkspaceID: command.WorkspaceID,
-			TimeEntryID: timeEntryID,
-			UserID:      command.UserID,
-			Billable:    command.Billable,
-			Description: command.Description,
-			Start:       command.Start,
-			Stop:        command.Stop,
-			Duration:    command.Duration,
-			ProjectID:   command.ProjectID,
-			TaskID:      command.TaskID,
-			TagIDs:      command.TagIDs,
-			ReplaceTags: command.ReplaceTags,
+			WorkspaceID:  command.WorkspaceID,
+			TimeEntryID:  timeEntryID,
+			UserID:       command.UserID,
+			Billable:     command.Billable,
+			Description:  command.Description,
+			Start:        command.Start,
+			Stop:         command.Stop,
+			Duration:     command.Duration,
+			ProjectID:    command.ProjectID,
+			TaskID:       command.TaskID,
+			TagIDs:       command.TagIDs,
+			ReplaceTags:  command.ReplaceTags,
+			AddTagIDs:    command.AddTagIDs,
+			RemoveTagIDs: command.RemoveTagIDs,
 		}
 		if _, err := service.UpdateTimeEntry(ctx, update); err != nil {
-			return nil, err
+			service.logger.WarnContext(ctx, "bulk patch failed for time entry",
+				"workspace_id", command.WorkspaceID,
+				"entry_id", timeEntryID,
+				"error", err.Error(),
+			)
+			failures = append(failures, PatchTimeEntryFailure{ID: timeEntryID, Message: err.Error()})
+			continue
 		}
 		success = append(success, timeEntryID)
 	}
-	return success, nil
+	return success, failures, nil
 }
 
 func (service *Service) StopTimeEntry(ctx context.Context, workspaceID int64, userID int64, timeEntryID int64) (TimeEntryView, error) {

--- a/apps/backend/internal/tracking/application/types.go
+++ b/apps/backend/internal/tracking/application/types.go
@@ -105,6 +105,12 @@ type UpdateTimeEntryCommand struct {
 	TaskID      *int64
 	TagIDs      []int64
 	ReplaceTags bool
+	// AddTagIDs and RemoveTagIDs express the incremental tag semantics Toggl's
+	// bulk patch uses for the `add` and `remove` ops on /tags: the entry keeps
+	// the tags it already has, minus/plus these. They are applied after
+	// ReplaceTags so a replace followed by an add still behaves sanely.
+	AddTagIDs    []int64
+	RemoveTagIDs []int64
 }
 
 type PatchTimeEntriesCommand struct {
@@ -120,6 +126,18 @@ type PatchTimeEntriesCommand struct {
 	TaskID       *int64
 	TagIDs       []int64
 	ReplaceTags  bool
+	AddTagIDs    []int64
+	RemoveTagIDs []int64
+}
+
+// PatchTimeEntryFailure reports one entry the bulk patch could not apply.
+// Toggl's contract for this endpoint is explicitly non-transactional ("patch
+// will be executed partially when there are errors with some records, no
+// transaction, no rollback"), so a failing entry must not abort the ones that
+// still succeed — it is reported here instead.
+type PatchTimeEntryFailure struct {
+	ID      int64
+	Message string
 }
 
 type FavoriteView struct {

--- a/apps/backend/internal/tracking/transport/http/public-api/handler_time_entries.go
+++ b/apps/backend/internal/tracking/transport/http/public-api/handler_time_entries.go
@@ -2,6 +2,7 @@ package publicapi
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -14,6 +15,10 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/samber/lo"
 )
+
+// maxBulkPatchTimeEntryIDs mirrors Toggl's documented cap for
+// PATCH /workspaces/{workspace_id}/time_entries/{time_entry_ids}.
+const maxBulkPatchTimeEntryIDs = 100
 
 func (handler *Handler) GetPublicTrackTimeEntries(ctx echo.Context) error {
 	workspaceID, user, err := handler.scope.RequirePublicTrackTrackingScope(ctx)
@@ -237,6 +242,14 @@ func (handler *Handler) PatchPublicTrackTimeEntries(ctx echo.Context) error {
 	if parseErr != nil || len(timeEntryIDs) == 0 {
 		return ctx.JSON(http.StatusBadRequest, "Bad Request")
 	}
+	// Toggl caps this endpoint at 100 ids per request; reject beyond that
+	// rather than silently accepting an unbounded fan-out.
+	if len(timeEntryIDs) > maxBulkPatchTimeEntryIDs {
+		return echo.NewHTTPError(
+			http.StatusBadRequest,
+			fmt.Sprintf("at most %d time entry ids per request", maxBulkPatchTimeEntryIDs),
+		)
+	}
 	var payload []publictrackapi.TimeentryPatchInput
 	if err := ctx.Bind(&payload); err != nil {
 		return ctx.JSON(http.StatusBadRequest, "Bad Request")
@@ -253,7 +266,7 @@ func (handler *Handler) PatchPublicTrackTimeEntries(ctx echo.Context) error {
 		}
 	}
 
-	success, err := handler.tracking.PatchTimeEntries(ctx.Request().Context(), command)
+	success, failures, err := handler.tracking.PatchTimeEntries(ctx.Request().Context(), command)
 	if err != nil {
 		return writePublicTrackTrackingError(err)
 	}
@@ -261,8 +274,19 @@ func (handler *Handler) PatchPublicTrackTimeEntries(ctx echo.Context) error {
 	for _, id := range success {
 		successIDs = append(successIDs, int(id))
 	}
+	// Entries that could not be patched are reported here rather than folded
+	// into `success`. Reporting a dropped entry as successful is what made the
+	// original bulk-edit bug invisible to callers.
+	failureViews := make([]publictrackapi.TimeentryPatchFailure, 0, len(failures))
+	for _, failure := range failures {
+		failureViews = append(failureViews, publictrackapi.TimeentryPatchFailure{
+			Id:      lo.ToPtr(int(failure.ID)),
+			Message: lo.ToPtr(failure.Message),
+		})
+	}
 	return ctx.JSON(http.StatusOK, publictrackapi.TimeentryPatchOutput{
 		Success: &successIDs,
+		Failure: &failureViews,
 	})
 }
 
@@ -270,6 +294,10 @@ func (handler *Handler) PatchPublicTrackTimeEntries(ctx echo.Context) error {
 // Unknown op, unknown path, or value-type mismatches produce a 400 instead of
 // being silently dropped — silent drops were the root cause of the bulk-edit
 // "200 OK but nothing saved" bug.
+//
+// Toggl accepts `add` and `remove` only on the tag paths, where they mean
+// "keep the entry's other tags" rather than "overwrite the tag list"; every
+// other path is `replace` only.
 func (handler *Handler) applyTimeEntryPatch(
 	ctx context.Context,
 	command *trackingapplication.PatchTimeEntriesCommand,
@@ -277,10 +305,15 @@ func (handler *Handler) applyTimeEntryPatch(
 ) error {
 	op := strings.TrimSpace(lo.FromPtr(patch.Op))
 	path := strings.TrimSpace(lo.FromPtr(patch.Path))
-	if !strings.EqualFold(op, "replace") {
+	value := interfaceValue(patch.Value)
+
+	switch {
+	case strings.EqualFold(op, "replace"):
+	case strings.EqualFold(op, "add"), strings.EqualFold(op, "remove"):
+		return handler.applyTimeEntryTagPatch(ctx, command, op, path, value)
+	default:
 		return echo.NewHTTPError(http.StatusBadRequest, "unsupported op: "+op)
 	}
-	value := interfaceValue(patch.Value)
 
 	switch path {
 	case "/description":
@@ -370,6 +403,59 @@ func (handler *Handler) applyTimeEntryPatch(
 	return nil
 }
 
+// applyTimeEntryTagPatch handles the `add` and `remove` ops, which Toggl only
+// defines for the tag paths. Unlike `replace`, these leave the entry's other
+// tags alone, so they are collected separately and resolved per entry.
+func (handler *Handler) applyTimeEntryTagPatch(
+	ctx context.Context,
+	command *trackingapplication.PatchTimeEntriesCommand,
+	op string,
+	path string,
+	value any,
+) error {
+	var ids []int64
+	switch path {
+	case "/tag_ids":
+		parsed, err := jsonPatchValueAsInt64Slice(value)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, "value for /tag_ids must be an array of integers")
+		}
+		ids = parsed
+	case "/tags":
+		names, err := jsonPatchValueAsStringSlice(value)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, "value for /tags must be an array of strings")
+		}
+		// `remove` must not create tags that do not exist yet, so only `add`
+		// goes through EnsureTagsByName.
+		if strings.EqualFold(op, "remove") {
+			resolved, err := handler.catalog.ResolveTagIDsByName(ctx, command.WorkspaceID, names)
+			if err != nil {
+				return writePublicTrackTrackingError(err)
+			}
+			ids = resolved
+		} else {
+			created, err := handler.catalog.EnsureTagsByName(ctx, command.WorkspaceID, command.UserID, names)
+			if err != nil {
+				return writePublicTrackTrackingError(err)
+			}
+			ids = created
+		}
+	default:
+		return echo.NewHTTPError(
+			http.StatusBadRequest,
+			"op "+op+" is only supported for /tags and /tag_ids, not "+path,
+		)
+	}
+
+	if strings.EqualFold(op, "remove") {
+		command.RemoveTagIDs = append(command.RemoveTagIDs, ids...)
+		return nil
+	}
+	command.AddTagIDs = append(command.AddTagIDs, ids...)
+	return nil
+}
+
 func (handler *Handler) StopPublicTrackTimeEntry(ctx echo.Context) error {
 	workspaceID, user, err := handler.scope.RequirePublicTrackTrackingScope(ctx)
 	if err != nil {
@@ -410,4 +496,3 @@ func (handler *Handler) resolveTagIDs(ctx context.Context, workspaceID int64, us
 	}
 	return nil, nil
 }
-


### PR DESCRIPTION
Follow-up to 4594396f, which made bulk patch actually apply `/project_id` and `/tags`. Checking our behaviour against Toggl's documented contract turned up three remaining divergences.

## What Toggl actually specifies

Per Toggl staff in [this thread](https://community.toggl.com/t/patch-bulk-editing-time-entries-projects-documentation/557):

- `replace`: `/description` `/project_id` `/task_id` `/billable` `/workspace_id` `/user_id` `/start` `/shared_with_user_ids`
- `add` / `remove`: `/tags` `/deleted_at` `/shared_with_user_ids`
- max 100 ids, [partial execution, no transaction, no rollback](https://community.toggl.com/t/time-entries-endpoints-patch-bulk-editing-time-entries/186), response `{success: [...], failure: [{id, message}]}`

## Changes

1. **`add` / `remove` on the tag paths** — previously a flat 400. They are incremental by definition (the entry keeps its other tags), so they map to new `AddTagIDs` / `RemoveTagIDs` fields applied per entry. `remove` resolves names via a new `ResolveTagIDsByName` instead of `EnsureTagsByName`, so it cannot create the tag it is removing.
2. **Partial failures** — one bad id aborted the batch. `PatchTimeEntries` now continues and returns `[]PatchTimeEntryFailure`; the handler fills the response's `failure` array, which was always `nil` before. Reporting a dropped entry as a success is what made the original bug invisible.
3. **100-id cap** — enforced with a 400 instead of an unbounded fan-out.

## Security tests

`TestSameWorkspaceUserACannotPatchUserBTimeEntries` asserted that a mixed batch mutates nothing. Under partial semantics the attacker's *own* entry may be patched — something they can do directly anyway — so that assertion now tracks the contract, and the denial of user B's entry is asserted through the failure list. Every no-mutation assertion on the victim's entries is unchanged.

## Verification

`go vet` clean; `go test ./internal/tracking/... ./internal/catalog/...` green against Postgres 17. Two new tests: incremental add/remove tag semantics, and a missing id landing in `failure` while the valid id still applies.

Not covered: `/deleted_at` and `/shared_with_user_ids` are still unsupported paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DqXdFyTfQZYP4rSLRrz8HV