### PR TITLE
fix(tracking): /me/time_entries must read across all the user's workspaces

### DIFF
--- a/apps/backend/internal/tracking/application/list_time_entries_scope_test.go
+++ b/apps/backend/internal/tracking/application/list_time_entries_scope_test.go
@@ -1,0 +1,94 @@
+package application_test
+
+import (
+	"context"
+	"slices"
+	"testing"
+	"time"
+
+	"opentoggl/backend/apps/backend/internal/testsupport/pgtest"
+	trackingapplication "opentoggl/backend/apps/backend/internal/tracking/application"
+)
+
+// TestListUserTimeEntries_ReadsAcrossEveryGivenWorkspace pins the account-wide
+// read behind /me/time_entries.
+//
+// The route used to collapse to the caller's "home" workspace
+// (web_user_homes), which is a different column from
+// users.default_workspace_id. Clients create entries against the default
+// workspace, so once the two drifted apart — creating a workspace in another
+// organization is enough — every entry the client wrote became invisible to
+// the list it read back, with no error anywhere: the CLI's live suite saw
+// "created ok" followed by an empty day list.
+func TestListUserTimeEntries_ReadsAcrossEveryGivenWorkspace(t *testing.T) {
+	database := pgtest.Open(t)
+	ctx := context.Background()
+
+	homeWorkspaceID, userID := seedTrackingWorkspaceWithUniqueEmail(t, ctx, database, "list-scope-home")
+	otherWorkspaceID, _ := seedTrackingWorkspaceWithUniqueEmail(t, ctx, database, "list-scope-other")
+
+	catalogService := mustNewTrackingCatalogService(t, database)
+	trackingService := mustNewTrackingService(t, database, catalogService, testLogger)
+
+	start := time.Date(2026, 4, 5, 9, 0, 0, 0, time.UTC)
+	stop := start.Add(time.Hour)
+	homeEntry, err := trackingService.CreateTimeEntry(ctx, trackingapplication.CreateTimeEntryCommand{
+		WorkspaceID: homeWorkspaceID,
+		UserID:      userID,
+		Description: "in home workspace",
+		Start:       start,
+		Stop:        &stop,
+		CreatedWith: "list-scope-test",
+	})
+	if err != nil {
+		t.Fatalf("create entry in home workspace: %v", err)
+	}
+	otherEntry, err := trackingService.CreateTimeEntry(ctx, trackingapplication.CreateTimeEntryCommand{
+		WorkspaceID: otherWorkspaceID,
+		UserID:      userID,
+		Description: "in the other workspace",
+		Start:       start.Add(2 * time.Hour),
+		Stop:        stopAt(start.Add(3 * time.Hour)),
+		CreatedWith: "list-scope-test",
+	})
+	if err != nil {
+		t.Fatalf("create entry in other workspace: %v", err)
+	}
+
+	entries, err := trackingService.ListUserTimeEntries(ctx, trackingapplication.ListTimeEntriesFilter{
+		UserID:       userID,
+		WorkspaceIDs: []int64{homeWorkspaceID, otherWorkspaceID},
+	})
+	if err != nil {
+		t.Fatalf("list across workspaces: %v", err)
+	}
+
+	ids := make([]int64, 0, len(entries))
+	for _, entry := range entries {
+		ids = append(ids, entry.ID)
+	}
+	if !slices.Contains(ids, homeEntry.ID) {
+		t.Fatalf("entry %d from the home workspace missing: %v", homeEntry.ID, ids)
+	}
+	if !slices.Contains(ids, otherEntry.ID) {
+		t.Fatalf("entry %d from the other workspace missing: %v", otherEntry.ID, ids)
+	}
+
+	// A single-workspace read must still be scoped to that workspace only.
+	scoped, err := trackingService.ListUserTimeEntries(ctx, trackingapplication.ListTimeEntriesFilter{
+		UserID:      userID,
+		WorkspaceID: homeWorkspaceID,
+	})
+	if err != nil {
+		t.Fatalf("list scoped to home workspace: %v", err)
+	}
+	for _, entry := range scoped {
+		if entry.ID == otherEntry.ID {
+			t.Fatalf("workspace-scoped read leaked entry %d from another workspace", otherEntry.ID)
+		}
+	}
+}
+
+func stopAt(value time.Time) *time.Time {
+	return &value
+}

--- a/apps/backend/internal/tracking/application/types.go
+++ b/apps/backend/internal/tracking/application/types.go
@@ -71,11 +71,16 @@ type MostActiveUserView struct {
 type ListTimeEntriesFilter struct {
 	UserID      int64
 	WorkspaceID int64
-	Since       *time.Time
-	Before      *time.Time
-	StartDate   *time.Time
-	EndDate     *time.Time
-	IncludeAll  bool
+	// WorkspaceIDs restricts the read to a set of workspaces. It is what the
+	// account-wide /me/time_entries routes use, so they stay correct when the
+	// user's home workspace and default workspace disagree. Ignored when
+	// WorkspaceID is set.
+	WorkspaceIDs []int64
+	Since        *time.Time
+	Before       *time.Time
+	StartDate    *time.Time
+	EndDate      *time.Time
+	IncludeAll   bool
 }
 
 type CreateTimeEntryCommand struct {

--- a/apps/backend/internal/tracking/infra/postgres/store_time_entries.go
+++ b/apps/backend/internal/tracking/infra/postgres/store_time_entries.go
@@ -265,9 +265,13 @@ func (store *Store) ListTimeEntriesForUser(
 	left join catalog_tasks t on t.id = te.task_id
 	where te.user_id = $1`
 	args := []any{filter.UserID}
-	if filter.WorkspaceID > 0 {
+	switch {
+	case filter.WorkspaceID > 0:
 		args = append(args, filter.WorkspaceID)
 		query += " and te.workspace_id = $" + intParam(len(args))
+	case len(filter.WorkspaceIDs) > 0:
+		args = append(args, filter.WorkspaceIDs)
+		query += " and te.workspace_id = any($" + intParam(len(args)) + ")"
 	}
 	if !filter.IncludeAll {
 		query += " and te.deleted_at is null"

--- a/apps/backend/internal/tracking/transport/http/public-api/handler_time_entries.go
+++ b/apps/backend/internal/tracking/transport/http/public-api/handler_time_entries.go
@@ -21,12 +21,20 @@ import (
 const maxBulkPatchTimeEntryIDs = 100
 
 func (handler *Handler) GetPublicTrackTimeEntries(ctx echo.Context) error {
-	workspaceID, user, err := handler.scope.RequirePublicTrackTrackingScope(ctx)
+	user, err := handler.scope.RequirePublicTrackUser(ctx)
+	if err != nil {
+		return err
+	}
+	// Account-wide by Toggl's definition: read across every workspace the user
+	// belongs to rather than the single "home" workspace, which drifts away
+	// from users.default_workspace_id and then hides entries created against
+	// the default.
+	workspaceIDs, err := handler.scope.ListPublicTrackUserWorkspaces(ctx)
 	if err != nil {
 		return err
 	}
 
-	filter := trackingapplication.ListTimeEntriesFilter{UserID: user.ID, WorkspaceID: workspaceID}
+	filter := trackingapplication.ListTimeEntriesFilter{UserID: user.ID, WorkspaceIDs: workspaceIDs}
 	if since, ok := queryInt64(ctx, "since"); ok {
 		timeValue := time.Unix(since, 0).UTC()
 		filter.Since = &timeValue
@@ -72,13 +80,17 @@ func (handler *Handler) GetPublicTrackTimeEntries(ctx echo.Context) error {
 }
 
 func (handler *Handler) GetPublicTrackTimeEntriesChecklist(ctx echo.Context) error {
-	workspaceID, user, err := handler.scope.RequirePublicTrackTrackingScope(ctx)
+	user, err := handler.scope.RequirePublicTrackUser(ctx)
+	if err != nil {
+		return err
+	}
+	workspaceIDs, err := handler.scope.ListPublicTrackUserWorkspaces(ctx)
 	if err != nil {
 		return err
 	}
 	entries, err := handler.tracking.ListUserTimeEntries(ctx.Request().Context(), trackingapplication.ListTimeEntriesFilter{
-		UserID:      user.ID,
-		WorkspaceID: workspaceID,
+		UserID:       user.ID,
+		WorkspaceIDs: workspaceIDs,
 	})
 	if err != nil {
 		return writePublicTrackTrackingError(err)

--- a/apps/backend/internal/tracking/transport/http/public-api/support.go
+++ b/apps/backend/internal/tracking/transport/http/public-api/support.go
@@ -18,6 +18,13 @@ type ScopeAuthorizer interface {
 	RequirePublicTrackUser(ctx echo.Context) (*identityapplication.UserSnapshot, error)
 	RequirePublicTrackWorkspace(ctx echo.Context, workspaceID int64) error
 	RequirePublicTrackTrackingScope(ctx echo.Context) (int64, *identityapplication.UserSnapshot, error)
+	// ListPublicTrackUserWorkspaces returns every workspace the authenticated
+	// user belongs to. The /me/time_entries routes read across all of them,
+	// matching official Toggl v9 semantics, instead of collapsing to the
+	// "home" workspace — web_user_homes drifts out of sync with
+	// users.default_workspace_id, and when it does, entries created through
+	// the default workspace become invisible to the list endpoint.
+	ListPublicTrackUserWorkspaces(ctx echo.Context) ([]int64, error)
 }
 
 type Handler struct {


### PR DESCRIPTION
## Symptom

toggl-cli's live suite went from all-green to five failures with no code change on either side — only the test account's shape changed (a workspace created in another organization). Every failure looks the same:

```
message: running time entry missing from current-day list
entries seen on final poll (0): []
raw final response: []
```

`entry start` reports success. `entry show <id>` finds the entry. `entry list` returns `[]`.

## Cause

`/me/time_entries` (and `/me/time_entries/checklist`) resolved their workspace through `RequirePublicTrackTrackingScope` → `web_user_homes` — the "home" workspace. Clients write against `users.default_workspace_id`, which is what `GET /me` advertises and what toggl-cli reads.

Those are two separate columns and they drift. Once they disagree, writes land in one workspace and the account-wide read looks in the other. The API returns 200 and an empty array — no error anywhere.

Notably every other failing surface was fine: `/workspaces/{id}/...` routes name their workspace explicitly, and the catalog module's `/me/*` endpoints already aggregate across workspaces. Only tracking still collapsed to home.

## Fix

Do what catalog already does, for the reason its own `ScopeAuthorizer` comment gives — `/me/*` list endpoints aggregate across every workspace the user belongs to, which is both the official Toggl v9 semantic and the only shape robust to `web_user_homes` drift.

- `ListPublicTrackUserWorkspaces` added to tracking's `ScopeAuthorizer`
- `ListTimeEntriesFilter.WorkspaceIDs` → `and te.workspace_id = any($n)`
- reads that name a workspace explicitly stay scoped to exactly that one

## Verification

`go vet` clean; `go test ./internal/tracking/... ./internal/catalog/...` green against Postgres 17. New regression test covers both directions: an account-wide read returns entries from two different workspaces, and a workspace-scoped read does not leak across.

## Note

The live instance is built by `docker.yml`, which only runs on `v*` tags — the last image is from 2026-07-03. toggl-cli's Live E2E job will keep failing until this ships in a tagged release. Until then the account-level workaround is to make the home workspace and the default workspace agree (switch to the default workspace in the web UI, or point `default_workspace_id` at the current home).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DqXdFyTfQZYP4rSLRrz8HV